### PR TITLE
Allow Authorization header to be set specifically

### DIFF
--- a/lib/http.rb
+++ b/lib/http.rb
@@ -175,7 +175,7 @@ module BubbleWrap
         puts "HTTP redirected #{request.description}" #if SETTINGS[:debug]
         new_request = request.mutableCopy
         new_request.setValue(@credentials.inspect, forHTTPHeaderField:'Authorization')
-        @request.setAllHTTPHeaderFields(@headers) if @headers
+        new_request.setAllHTTPHeaderFields(@headers) if @headers
         # p @request.allHTTPHeaderFields.description
         @connection.cancel
         @connection = NSURLConnection.connectionWithRequest(new_request, delegate:self)


### PR DESCRIPTION
In https://github.com/mattetti/BubbleWrap/pull/13, the credentials option was added to the Authorization header. This tramples on any other use of the `Authorization` header, such as a token for an Oauth2 implementation.

Immediately after setting the header in `new_request`, the original request object has it's explicit headers re-applied, but the actual request is made with `new_request`, so that has no effect. The result of this is that the specified Authorization header is ignored.

This pull request re-applies the header fields to the `new_request` object, which should fix this issue.
