### PR TITLE
Adjusted Kernel Alert to behave as in examples

### DIFF
--- a/lib/kernel.rb
+++ b/lib/kernel.rb
@@ -80,7 +80,7 @@ module Kernel
                                               delegate: nil, 
                                               cancelButtonTitle: "OK", 
                                               otherButtonTitles: nil
-    alert
+    alert.show
   end
 
   def simulator?


### PR DESCRIPTION
Fixed alert so it actually calls show.  This is how it's used in the examples of the README, so I've edited it to correspond.  Perhaps a secondary helper for returning the alert object, in case someone wants to change the alertViewStyle etc?

Let me know and I'll be happy to add that, too.
