### PR TITLE
Allowing string/symbol keys for defaults

### DIFF
--- a/lib/bubble-wrap/app.rb
+++ b/lib/bubble-wrap/app.rb
@@ -31,19 +31,19 @@ module App
 
     def self.[]=(key, value)
       defaults = NSUserDefaults.standardUserDefaults
-      defaults.setObject(value, forKey: storage_key(key))
+      defaults.setObject(value, forKey: storage_key(key.to_s))
       defaults.synchronize
     end
 
     def self.[](key)
       defaults = NSUserDefaults.standardUserDefaults
-      defaults.objectForKey storage_key(key)
+      defaults.objectForKey storage_key(key.to_s)
     end
 
     private
 
     def self.storage_key(key)
-      app_key + '_' + key
+      app_key + '_' + key.to_s
     end
   end
 

--- a/lib/bubble-wrap/ns_user_defaults.rb
+++ b/lib/bubble-wrap/ns_user_defaults.rb
@@ -4,12 +4,12 @@ class NSUserDefaults
 
   # Retrieves the object for the passed key
   def [](key)
-    self.objectForKey(key)
+    self.objectForKey(key.to_s)
   end
 
   # Sets the value for a given key and save it right away.
   def []=(key, val)
-    self.setObject(val, forKey: key)
+    self.setObject(val, forKey: key.to_s)
     self.synchronize
   end
 end


### PR DESCRIPTION
Allowing strings or symbols as the key to persistence objects. Both access the same value:

``` ruby
App::Persistence[:key]
App::Persistence["key"]
```
