### PR TITLE
Proper handling of installation under /Library/Ruby/Gems

### DIFF
--- a/lib/bubble-wrap.rb
+++ b/lib/bubble-wrap.rb
@@ -11,7 +11,7 @@ module Motion
       # dependencies.
       def files_dependencies(deps_hash)
         res_path = lambda do |x|
-          path = /^\.|\/Users\/|\/Library\//.match(x) ? x : File.join('.', x)
+          path = /^\.?\//.match(x) ? x : File.join('.', x)
           unless @files.include?(path)
             App.fail "Can't resolve dependency `#{x}' because #{path} is not in #{@files.inspect}"
           end


### PR DESCRIPTION
If you use the included system ruby installed under `/Library/Ruby`, and install bubble-wrap there, the `files_dependencies` method was incorrectly trying to prepend the path with `./`.

This fix will not try to add `./` to anything under `/Library`
