### PR TITLE
Append to files and frameworks rather than assign

### DIFF
--- a/lib/bubble-wrap/ext/motion_project_app.rb
+++ b/lib/bubble-wrap/ext/motion_project_app.rb
@@ -6,9 +6,9 @@ module BubbleWrap
         base.instance_eval do
           def setup_with_bubblewrap(&block)
             bw_config = proc do |app|
-              app.files = ::BubbleWrap::Requirement.files + Dir.glob('./app/**/*.rb')
+              app.files += ::BubbleWrap::Requirement.files + Dir.glob('./app/**/*.rb')
               app.files_dependencies ::BubbleWrap::Requirement.files_dependencies
-              app.frameworks = ::BubbleWrap::Requirement.frameworks
+              app.frameworks += ::BubbleWrap::Requirement.frameworks
               block.call(app)
             end
             configs.each_value &bw_config


### PR DESCRIPTION
So that other gems can specify their own as well. Specs pass.
