### PR TITLE
Adding in in to documentation since alert isn't on the kernal anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ BubbleWrap::HTTP.post("http://foo.bar.com/", {payload: data}) do |response|
     json = BubbleWrap::JSON.parse(response.body.to_str)
     p json['id']
   elsif response.status_code.to_s =~ /40\d/
-    App.alert("Login failed") # helper provided by the kernel file in this repo.
+    App.alert("Login failed")
   else
     App.alert(response.error_message)
   end


### PR DESCRIPTION
In the readme in the HTTP example it included `alert` not `App.alert`. So I fixed it :)
