### PR TITLE
Added upload support in HTTP

### DIFF
--- a/motion/http.rb
+++ b/motion/http.rb
@@ -112,7 +112,6 @@ module BubbleWrap
         @payload = options.delete(:payload)
         @files = options.delete(:files)
         @boundary = options.delete(:boundary)
-        # boundary is needed to separate post data, it is randomly generated with a uuid if nil
         if @boundary.nil? && !@files.nil?
           uuid = CFUUIDCreate(nil)
           @boundary = CFUUIDCreateString(nil, uuid)
@@ -169,7 +168,6 @@ module BubbleWrap
                                                       cachePolicy:@cache_policy,
                                                       timeoutInterval:@timeout)
         @request.setHTTPMethod @method
-        # if no header is specified, set multipart/dorm-data as default header
         @headers = {"Content-Type" => "multipart/form-data; boundary=#{@boundary}"} if !@files.nil? && @headers.nil?
         @request.setAllHTTPHeaderFields(@headers) if @headers
 
@@ -178,7 +176,6 @@ module BubbleWrap
           @body = NSMutableData.data
           @body.appendData(@payload.to_s.dataUsingEncoding(NSUTF8StringEncoding)) unless @payload.nil? || !@files.nil?
           
-          # for each data sent with payload, data has to be surrounded by boundary
           unless @files.nil? || @payload.nil?
             @payload.each { |key, value|
               postData = NSMutableData.data
@@ -191,7 +188,6 @@ module BubbleWrap
             }
           end
           
-          # for each data sent with files, data has to be surrounded by boundary
           unless @files.nil?
             @files.each { |key, value|
               postData = NSMutableData.data
@@ -204,7 +200,6 @@ module BubbleWrap
               @body.appendData(postData)
             }
           end
-          # this closes post data
           @body.appendData("\r\n--#{@boundary}--\r\n".dataUsingEncoding(NSUTF8StringEncoding)) unless @files.nil?
           
           @request.setHTTPBody @body


### PR DESCRIPTION
I wrote a little patch to enable uploads with the HTTP wrapper.
I'm a beginner so the code may be a bit dirty, feel free to improve it.

It's inspired from ASI HTTP Request.

How to use:

`BW::HTTP.post(url, {:payload => {[name] => [value]}, :files => {[name] => [NSData]}}) do |response|; end`

Sorry I haven't written tests, I don't know how to do > .<
