### PR TITLE
Adds support for setting the message and passing a block to App.alert

### DIFF
--- a/motion/core/app.rb
+++ b/motion/core/app.rb
@@ -1,4 +1,4 @@
-# Provides a module to store global states 
+# Provides a module to store global states
 #
 module BubbleWrap
   module App
@@ -26,12 +26,30 @@ module BubbleWrap
       NSUserDefaults.standardUserDefaults
     end
 
-    def alert(msg,cancelButtonTitle='OK')
-      alert = UIAlertView.alloc.initWithTitle msg, 
-        message: nil,
-        delegate: nil, 
-        cancelButtonTitle: cancelButtonTitle,
+    # Displays a UIAlertView.
+    #
+    # title - The title as a String.
+    # args  - The title of the cancel button as a String, or a Hash of options.
+    #         (Default: { cancel_button_title: 'OK' })
+    #         cancel_button_title - The title of the cancel button as a String.
+    #         message             - The main message as a String.
+    # block - Yields the alert object if a block is given, and does so before the alert is shown.
+    def alert(title, *args, &block)
+      options = { cancel_button_title: 'OK' }
+      options.merge!(args.pop) if args.last.is_a?(Hash)
+
+      if args.size > 0 && args.first.is_a?(String)
+        options[:cancel_button_title] = args.shift
+      end
+
+      alert = UIAlertView.alloc.initWithTitle title,
+        message: options[:message],
+        delegate: nil,
+        cancelButtonTitle: options[:cancel_button_title],
         otherButtonTitles: nil
+
+      yield(alert) if block_given?
+
       alert.show
       alert
     end

--- a/spec/motion/core/app_spec.rb
+++ b/spec/motion/core/app_spec.rb
@@ -5,7 +5,7 @@ describe BubbleWrap::App do
     end
   end
 
-  describe '.resources_path' do 
+  describe '.resources_path' do
     it 'should end in "/testSuite.app"' do
       BW::App.resources_path.should =~ /\/testSuite(_spec)?.app$/
     end
@@ -24,29 +24,114 @@ describe BubbleWrap::App do
   end
 
   describe '.alert' do
-    before do
-      @alert = BW::App.alert('1.21 Gigawatts!', 'Great Scott!')
-    end
-
     after do
       @alert.removeFromSuperview
     end
 
-    it 'returns an alert' do
-      @alert.class.should == UIAlertView
-    end
-
-    it 'is displaying the correct title' do
-      @alert.title.should == '1.21 Gigawatts!'
-    end
-
-    describe 'cancelButton' do
-      it 'is present' do
-        @alert.cancelButtonIndex.should == 0
+    describe "with only one string argument" do
+      before do
+        @alert = BW::App.alert('1.21 Gigawatts!')
       end
 
-      it 'has the correct title' do
-        @alert.buttonTitleAtIndex(@alert.cancelButtonIndex).should == 'Great Scott!'
+      it 'returns an alert' do
+        @alert.class.should == UIAlertView
+      end
+
+      it 'is displaying the correct title' do
+        @alert.title.should == '1.21 Gigawatts!'
+      end
+
+      describe 'cancelButton' do
+        it 'is present' do
+          @alert.cancelButtonIndex.should == 0
+        end
+
+        it 'has the correct title' do
+          @alert.buttonTitleAtIndex(@alert.cancelButtonIndex).should == 'OK'
+        end
+      end
+    end
+
+    describe "with only two string arguments" do
+      before do
+        @alert = BW::App.alert('1.21 Gigawatts!', 'Great Scott!')
+      end
+
+      it 'returns an alert' do
+        @alert.class.should == UIAlertView
+      end
+
+      it 'is displaying the correct title' do
+        @alert.title.should == '1.21 Gigawatts!'
+      end
+
+      describe 'cancelButton' do
+        it 'is present' do
+          @alert.cancelButtonIndex.should == 0
+        end
+
+        it 'has the correct title' do
+          @alert.buttonTitleAtIndex(@alert.cancelButtonIndex).should == 'Great Scott!'
+        end
+      end
+    end
+
+    describe "with variable args" do
+      before do
+        @alert = BW::App.alert('1.21 Gigawatts!', cancel_button_title: 'Great Scott!',
+                                                  message: 'Some random message')
+      end
+
+      it 'returns an alert' do
+        @alert.class.should == UIAlertView
+      end
+
+      it 'is displaying the correct title' do
+        @alert.title.should == '1.21 Gigawatts!'
+      end
+
+      it 'is displaying the correct message' do
+        @alert.message.should == 'Some random message'
+      end
+
+      describe 'cancelButton' do
+        it 'is present' do
+          @alert.cancelButtonIndex.should == 0
+        end
+
+        it 'has the correct title' do
+          @alert.buttonTitleAtIndex(@alert.cancelButtonIndex).should == 'Great Scott!'
+        end
+      end
+    end
+
+    describe "with a block" do
+      before do
+        @alert = BW::App.alert('1.21 Gigawatts!') do |alert|
+          alert.message = 'My message!!'
+        end
+      end
+
+      it 'returns an alert' do
+        @alert.class.should == UIAlertView
+      end
+
+      it 'is displaying the correct title' do
+        @alert.title.should == '1.21 Gigawatts!'
+      end
+
+      it 'is displaying the correct message' do
+        @alert.message.should == 'My message!!'
+      end
+
+      describe 'cancelButton' do
+        it 'is present' do
+          @alert.cancelButtonIndex.should == 0
+        end
+
+        it 'has the correct title' do
+          @alert.buttonTitleAtIndex(@alert.cancelButtonIndex).should == 'OK'
+        end
       end
     end
   end
@@ -121,7 +206,7 @@ describe BubbleWrap::App do
       application.url.class.should.equal NSURL
       application.url.description.should.equal url
     end
-    
+
   end
 
 end


### PR DESCRIPTION
As the title says. You currently cannot set the message or do anything much with the alert object, as it is shown before you get access to it.

So now you can do this:

```
App.alert 'My title', message: 'My message' do |alert|
  alert.addButtonWithTitle 'My 2nd button'
end
```

And you can still do this:

```
App.alert 'My Title', 'My 1st Button'
```
