### PR TITLE
Pass gesture reconizer to the block in UIGestureRegonizer helpers

### DIFF
--- a/motion/ui/gestures.rb
+++ b/motion/ui/gestures.rb
@@ -26,13 +26,11 @@ class UIView
     addGestureRecognizerHelper(proc, enableInteraction, UILongPressGestureRecognizer.alloc.initWithTarget(self, action:'motionHandleGesture:'))
   end
 
-  protected
+  private
 
   def motionHandleGesture(recognizer)
     @recognizers[recognizer].call(recognizer)
   end
-
-  private
 
   # Adds the recognizer and keeps a strong reference to the Proc object.
   def addGestureRecognizerHelper(proc, enableInteraction, recognizer)
@@ -44,4 +42,3 @@ class UIView
   end
 
 end
-


### PR DESCRIPTION
Workaround motion issue on Proc#call that cannot be called by ObjC, fixes #80.
