### PR TITLE
Alias .new... to .alloc.initWith...

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,19 @@ end
 Helper methods added to the class repsonsible for user preferences used
 by the `App::Persistence` module shown below.
 
+### Object
+
+RubyMotion already converts `Class.new` to `Class.alloc.init`. Now, you
+can use this everywhere to initialize objects with arguments:
+
+```ruby
+UIWindow.alloc.initWithFrame UIScreen.mainScreen.bounds # Before
+UIWindow.newWithFrame UIScreen.mainScreen.bounds # After
+
+UIColor.alloc.initWithRed 1.0, green: 1.0, blue: 1.0, alpha: 1.0 # Before
+UIColor.newWithRed 1.0, green: 1.0, blue: 1.0, alpha: 1.0 # After
+```
+
 ### Persistence
 
 Offers a way to persist application specific information using a very

--- a/motion/core/object.rb
+++ b/motion/core/object.rb
@@ -1,0 +1,30 @@
+module BubbleWrap
+  module Object
+    def method_missing(method, *args)
+      if method.to_s =~ /^new[A-Z].+/
+        return delegate_new_to_alloc_init method, *args
+      end
+
+      super
+    end
+
+    private
+
+    def delegate_new_to_alloc_init(method, *args)
+      methods = [method.to_s.gsub(/^new/, 'init')]
+
+      if args.last.is_a? Hash
+        inline_arguments = args.pop
+
+        inline_arguments.each do |key, value|
+          methods << key
+          args << value
+        end
+      end
+
+      self.alloc.send methods.join(':'), *args
+    end
+  end
+end
+
+Object.send :extend, BubbleWrap::Object

--- a/spec/motion/core/object_spec.rb
+++ b/spec/motion/core/object_spec.rb
@@ -1,0 +1,25 @@
+describe BubbleWrap::Object do
+  describe '.delegate_new_to_alloc_init' do
+    it 'sends methods starting with new to .alloc.init...' do
+      lambda {
+        @ui_view = UIView.newWithFrame [[0,0],[0,0]]
+      }.should.not.raise NoMethodError
+
+      @ui_view.class.should.equal UIView
+    end
+
+    it 'supports methods with inline arguments' do
+      lambda {
+        @ui_color = UIColor.newWithRed 1.0, green: 1.0, blue: 1.0, alpha: 1.0
+      }.should.not.raise NoMethodError
+
+      @ui_color.alphaComponent.should.equal 1.0
+    end
+
+    it 'delegates other methods to super' do
+      lambda {
+        Object.someOtherNonexistentMethod
+      }.should.raise NoMethodError
+    end
+  end
+end


### PR DESCRIPTION
This uses method_missing to delegate class methods such as `UIView.newWithFrame` to `UIView.alloc.initWithFrame`.

``` ruby
UIWindow.alloc.initWithFrame UIScreen.mainScreen.bounds # Before
UIWindow.newWithFrame UIScreen.mainScreen.bounds # After

UIColor.alloc.initWithRed 1.0, green: 1.0, blue: 1.0, alpha: 1.0 # Before
UIColor.newWithRed 1.0, green: 1.0, blue: 1.0, alpha: 1.0 # After
```
