### PR TITLE
Add merge to Persistence

### DIFF
--- a/motion/core/persistence.rb
+++ b/motion/core/persistence.rb
@@ -16,6 +16,12 @@ module BubbleWrap
       storage.objectForKey storage_key(key.to_s)
     end
 
+    def merge(values)
+      values = Hash[values.map{|key, value| [storage_key(key.to_s), value]}]
+      storage.registerDefaults values
+      storage.synchronize
+    end
+
     def storage
       NSUserDefaults.standardUserDefaults
     end

--- a/spec/motion/core/persistence_spec.rb
+++ b/spec/motion/core/persistence_spec.rb
@@ -30,13 +30,35 @@ describe BubbleWrap::Persistence do
       BubbleWrap::Persistence['arbitraryNumber'] = 42
       storage.instance_variable_get(:@sync_was_called).should.equal true
     end 
+  end
 
+  describe "storing multiple objects" do
+    it 'can persist multiple objects' do
+      lambda do
+        BubbleWrap::Persistence.merge({
+          :anotherArbitraryNumber => 9001,
+          :arbitraryString => 'test string'
+        })
+      end.
+        should.not.raise(Exception)
+    end
+
+    it 'must call synchronize' do
+      storage = NSUserDefaults.standardUserDefaults
+      def storage.synchronize; @sync_was_called = true; end
+
+      BubbleWrap::Persistence.merge({
+        :anotherArbitraryNumber => 9001,
+        :arbitraryString => 'test string'
+      })
+      storage.instance_variable_get(:@sync_was_called).should.equal true
+    end
   end
 
   describe "retrieving objects" do
     it 'can retrieve persisted objects' do
       BubbleWrap::Persistence['arbitraryNumber'].should == 42
-    end  
+      BubbleWrap::Persistence[:arbitraryString].should == 'test string'
+    end
   end
-
 end


### PR DESCRIPTION
This allows the setting of multiple values at once which can be both convenient and also allow someone to set multiple values through the bubble wrap interface with only one call to synchronize.
