### PR TITLE
color keyword support in String#to_color

### DIFF
--- a/motion/core/string.rb
+++ b/motion/core/string.rb
@@ -34,6 +34,11 @@ module BubbleWrap
     end
 
     def to_color
+      # First check if it is a color keyword
+      keyword_selector = "#{self.camelize(false)}Color"
+      return UIColor.send(keyword_selector) if UIColor.respond_to? keyword_selector
+
+      # Next attempt to convert from hex
       hex_color = self.gsub("#", "")   
       case hex_color.size 
         when 3

--- a/spec/motion/core/string_spec.rb
+++ b/spec/motion/core/string_spec.rb
@@ -90,6 +90,20 @@ describe BubbleWrap::String do
     end 
   end 
 
+  describe "a string with a color keyword (blue, red, lightText)" do
+    it "should return the corresponding color" do
+      'blue'.to_color.should == UIColor.blueColor
+    end
+
+    it "should accept camelCase" do
+      'lightText'.to_color.should == UIColor.lightTextColor
+    end
+
+    it "should accept snake_case" do
+      'dark_gray'.to_color.should == UIColor.darkGrayColor
+    end
+  end
+
   describe "A UIColor should not be created from an invalid String wuth" do
 
 


### PR DESCRIPTION
Example: 'dark_text'.to_color -> UIColor.darkTextColor

I think this is a nice convenience, with low enough overhead.
