### PR TITLE
Remove unnecessary CFRelease call

### DIFF
--- a/motion/core.rb
+++ b/motion/core.rb
@@ -22,9 +22,7 @@ module BubbleWrap
 
   def create_uuid
     uuid = CFUUIDCreate(nil)
-    uuid_string = CFUUIDCreateString(nil, uuid)
-    CFRelease(uuid)
-    uuid_string
+    CFUUIDCreateString(nil, uuid)
   end
-  
+
 end


### PR DESCRIPTION
Per a support ticket discussion with Laurent while troubleshooting some iOS 6 issues:

> It is not necessary to call CFRelease in RubyMotion, as even CFType objects are automatically managed by the runtime. Calling it will result in the object being double-freed, which can potentially cause a crash later on.
