### PR TITLE
Properly strip paths with trailing /lib

### DIFF
--- a/lib/bubble-wrap/requirement/path_manipulation.rb
+++ b/lib/bubble-wrap/requirement/path_manipulation.rb
@@ -22,13 +22,17 @@ module BubbleWrap
       end
 
       def strip_up_to_last_lib(path)
-        path = path.split('lib')
-        path = if path.size > 1
-                 path[0..-2].join('lib')
-               else
-                 path[0]
-               end
-        path = path[0..-2] if path[-1] == '/'
+        if path =~ /\/lib$/
+          path = path.gsub(/\/lib$/, "")
+        else
+          path = path.split('lib')
+          path = if path.size > 1
+                   path[0..-2].join('lib')
+                 else
+                   path[0]
+                 end
+          path = path[0..-2] if path[-1] == '/'
+        end
         path
       end
 

--- a/spec/lib/bubble-wrap/requirement/path_manipulation_spec.rb
+++ b/spec/lib/bubble-wrap/requirement/path_manipulation_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../../../../../lib/bubble-wrap/requirement/path_manipulation', __FILE__)
 
 describe BubbleWrap::Requirement::PathManipulation do
-  
+
   before do
     @subject = Object.new
     @subject.extend BubbleWrap::Requirement::PathManipulation
@@ -32,6 +32,11 @@ describe BubbleWrap::Requirement::PathManipulation do
   describe '#strip_up_to_last_lib' do
     it 'strips off from the last lib' do
       @subject.strip_up_to_last_lib('/fake/lib/dir/lib/foo').
+        should == '/fake/lib/dir'
+    end
+
+    it "strips off only a trailing lib" do
+      @subject.strip_up_to_last_lib('/fake/lib/dir/lib').
         should == '/fake/lib/dir'
     end
 


### PR DESCRIPTION
This fixes Issue #103. 

Now a path like this:

```
/Users/dylan/.rbenv/versions/1.9.3-p194-perf/lib/ruby/gems/1.9.1/bundler/gems/formotion-0.0.5/lib
```

Will properly be stripped to:

```
/Users/dylan/.rbenv/versions/1.9.3-p194-perf/lib/ruby/gems/1.9.1/bundler/gems/formotion-0.0.5
```
