### PR TITLE
Bring back nested params support for POST requests

### DIFF
--- a/motion/http.rb
+++ b/motion/http.rb
@@ -296,7 +296,8 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
       end
 
       def convert_payload_to_url
-        params_array = generate_get_params(@payload)
+        params_array = process_payload_hash(@payload)
+        params_array.map! { |key, value| "#{key}=#{value}" }
         @payload = params_array.join("&")
       end
 
@@ -309,20 +310,15 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
             list += param
           elsif v.is_a?(Array)
             v.each do |val|
-              param = prefix ? "#{prefix}[#{k}][]" : "#{k}[]"
+              param = prefix ? "#{prefix}[#{k.to_s}][]" : "#{k.to_s}[]"
               list << [param, val]
             end
           else
-            param = prefix ? "#{prefix}[#{k}]" : k
+            param = prefix ? "#{prefix}[#{k.to_s}]" : k.to_s
             list << [param, v]
           end
         end
         list
-      end
-
-      def generate_get_params(payload)
-        list = process_payload_hash(payload)
-        list.map { |key, value| "#{key}=#{value}" }
       end
 
       def log(message)

--- a/spec/motion/http_spec.rb
+++ b/spec/motion/http_spec.rb
@@ -373,21 +373,21 @@ describe "HTTP" do
 
     end
 
-    describe "Generating GET params" do
+    describe "Generating payloads" do
 
-      it "should create params with nested hashes with prefix[key]=value" do
+      it "should create payload key/value pairs from nested hashes with prefix[key]=value" do
         expected_params = [
-          'user[name]=marin',
-          'user[surname]=usalj',
-          'twitter=@mneorr',
-          'website=mneorr.com',
-          'values[]=apple',
-          'values[]=orange',
-          'values[]=peach',
-          "credentials[username]=mneorr",
-          "credentials[password]=123456xx!@crazy"
+          ['user[name]', 'marin'],
+          ['user[surname]', 'usalj'],
+          ['twitter', '@mneorr'],
+          ['website', 'mneorr.com'],
+          ['values[]', 'apple'],
+          ['values[]', 'orange'],
+          ['values[]', 'peach'],
+          ['credentials[username]', 'mneorr'],
+          ['credentials[password]', '123456xx!@crazy']
         ]
-        @query.send(:generate_get_params, @payload).should.equal expected_params
+        @query.send(:process_payload_hash, @payload).should.equal expected_params
       end
 
     end


### PR DESCRIPTION
This brings back support for payloads with nested hashes in POST/PUT requests (originally added in #25, but later broken when adding multipart form-data support).
