### PR TITLE
Format option for setting Content-Type

### DIFF
--- a/motion/http.rb
+++ b/motion/http.rb
@@ -222,13 +222,13 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
         return nil if (@method == "GET" || @method == "HEAD")
         return nil unless (@payload || @files)
 
-        set_content_type
-
         body = NSMutableData.data
 
         append_payload(body) if @payload
         append_files(body) if @files
         append_body_boundary(body) if @set_body_to_close_boundary
+
+        set_content_type
 
         log "Built HTTP body: \n #{body.to_str}"
         body
@@ -239,12 +239,19 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
         if @headers.nil? || !@headers.keys.find {|k| k.downcase == 'content-type'}
           @headers ||= {}
           @headers["Content-Type"] = case @format
-                                     when :json then "application/json"
-                                     when :xml then "application/xml"
-                                     when :form_encoded then "application/x-www-form-urlencoded"
-                                     when :text then "text/plain"
-                                     else "multipart/form-data; boundary=#{@boundary}"
-                                     end
+          when :json
+            "application/json"
+          when :xml
+            "application/xml"
+          when :text
+            "text/plain"
+          else
+            if @format == :form_data || @set_body_to_close_boundary
+              "multipart/form-data; boundary=#{@boundary}"
+            else
+             "application/x-www-form-urlencoded"
+            end
+          end
         end
       end
 


### PR DESCRIPTION
From the discussion in #108, this adds support for a `format` parameter, and sets reasonable default content types when neither a content type nor a format is provided. 

For now, the format parameter is only used to decide on a Content-Type header. However, it could be used in the future to set accept headers, automatically manipulate payloads (e.g. `format: :json` might result in the payload being converted to a JSON string before sending), etc.

Formats provided are:
- `text` (text/plain)
- `json` (application/json)
- `xml` (application/xml)
- `form_data` (multipart/form-data)
- `form_encoded` (application/x-www-form-urlencoded)

When a format is not provided, the default is `form_encoded`. However, if there is a hash-based payload or files to upload, it defaults to `form_data` instead.
