### PR TITLE
accessing UIApplication.sharedApplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Other available methods:
 * `App.states`
 * `App.frame`
 * `App.delegate`
-* `App.app`
+* `App.shared`
 * `App.current_locale`
 
 

--- a/motion/core/app.rb
+++ b/motion/core/app.rb
@@ -106,7 +106,7 @@ module BubbleWrap
     end
 
     # the Application object.
-    def app
+    def shared
       UIApplication.sharedApplication
     end
 

--- a/spec/motion/core/app_spec.rb
+++ b/spec/motion/core/app_spec.rb
@@ -178,7 +178,7 @@ describe BubbleWrap::App do
 
   describe '.app' do
     it 'returns UIApplication.sharedApplication' do
-      BW::App.app.should == UIApplication.sharedApplication
+      BW::App.shared.should == UIApplication.sharedApplication
     end
   end
 


### PR DESCRIPTION
There are lots of ways to access _properties_ of `UIApplication.sharedApplication` (e.g. `App.delegate`), but no way to access the object directly!

`App.app` => `UIApplication.sharedApplication`
