### PR TITLE
Remove first line beak on multipart posts

### DIFF
--- a/motion/http.rb
+++ b/motion/http.rb
@@ -271,7 +271,9 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
           list = process_payload_hash(@payload)
           list.each do |key, value|
             form_data = NSMutableData.new
-            s = "\r\n--#{@boundary}\r\n"
+            s = ""
+            s += "\r\n" unless body.length == 0
+            s += "--#{@boundary}\r\n"
             s += "Content-Disposition: form-data; name=\"#{key}\"\r\n\r\n"
             s += value.to_s
             form_data.appendData(s.dataUsingEncoding NSUTF8StringEncoding)
@@ -285,7 +287,9 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
       def append_files(body)
         @files.each do |key, value|
           file_data = NSMutableData.new
-          s = "\r\n--#{@boundary}\r\n"
+          s = ""
+          s += "\r\n" unless body.length == 0
+          s += "--#{@boundary}\r\n"
           s += "Content-Disposition: form-data; name=\"#{key}\"; filename=\"#{key}\"\r\n"
           s += "Content-Type: application/octet-stream\r\n\r\n"
           file_data.appendData(s.dataUsingEncoding NSUTF8StringEncoding)

--- a/spec/motion/http_spec.rb
+++ b/spec/motion/http_spec.rb
@@ -232,7 +232,7 @@ describe "HTTP" do
             query = BubbleWrap::HTTP::Query.new( 'nil' , method, { payload: payload, files: files } )
             uuid = query.instance_variable_get(:@boundary)
             real_payload = NSString.alloc.initWithData(query.request.HTTPBody, encoding:NSUTF8StringEncoding)
-            real_payload.should.equal "\r\n--#{uuid}\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\napple\r\n--#{uuid}\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nmacbook\r\n--#{uuid}\r\nContent-Disposition: form-data; name=\"twitter\"; filename=\"twitter\"\r\nContent-Type: application/octet-stream\r\n\r\ntwitter:@mneorr\r\n--#{uuid}\r\nContent-Disposition: form-data; name=\"site\"; filename=\"site\"\r\nContent-Type: application/octet-stream\r\n\r\nmneorr.com\r\n--#{uuid}--\r\n"
+            real_payload.should.equal "--#{uuid}\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\napple\r\n--#{uuid}\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nmacbook\r\n--#{uuid}\r\nContent-Disposition: form-data; name=\"twitter\"; filename=\"twitter\"\r\nContent-Type: application/octet-stream\r\n\r\ntwitter:@mneorr\r\n--#{uuid}\r\nContent-Disposition: form-data; name=\"site\"; filename=\"site\"\r\nContent-Type: application/octet-stream\r\n\r\nmneorr.com\r\n--#{uuid}--\r\n"
           end
 
           [:get, :head].each do |method|
@@ -264,7 +264,7 @@ describe "HTTP" do
           query = BubbleWrap::HTTP::Query.new( 'nil', :post, { payload: payload } )
           uuid = query.instance_variable_get(:@boundary)
           real_payload = NSString.alloc.initWithData(query.request.HTTPBody, encoding:NSUTF8StringEncoding)
-          real_payload.should.equal "\r\n--#{uuid}\r\nContent-Disposition: form-data; name=\"computer[name]\"\r\n\r\napple\r\n--#{uuid}\r\nContent-Disposition: form-data; name=\"computer[model]\"\r\n\r\nmacbook\r\n--#{uuid}--\r\n"
+          real_payload.should.equal "--#{uuid}\r\nContent-Disposition: form-data; name=\"computer[name]\"\r\n\r\napple\r\n--#{uuid}\r\nContent-Disposition: form-data; name=\"computer[model]\"\r\n\r\nmacbook\r\n--#{uuid}--\r\n"
         end
 
       end


### PR DESCRIPTION
I've tried to use BubbleWrap with an older Rails 2.3 application and I constantly got `bad content body` errors in the rails app. 

```
/!\ FAILSAFE /!\  20 July 2012 13:44
  Status: 500 Internal Server Error
  bad content body
    .../rack-1.1.3/lib/rack/utils.rb:518:in `parse_multipart'
  ... 
```

With curl it did work as expected. The difference between curl and BubbleWrap was a line break at the beginning of `Content-Disposition`.
Removing that line break solved the problem.
