### PR TITLE
Add a bubble-wrap demo to show how to use the location wrapper

### DIFF
--- a/samples/location/.gitignore
+++ b/samples/location/.gitignore
@@ -1,0 +1,5 @@
+.repl_history
+build
+resources/*.nib
+resources/*.momd
+resources/*.storyboardc

--- a/samples/location/Gemfile
+++ b/samples/location/Gemfile
@@ -1,0 +1,3 @@
+source :rubygems
+
+gem 'bubble-wrap', '~> 1.1.0'

--- a/samples/location/README.md
+++ b/samples/location/README.md
@@ -1,0 +1,4 @@
+## Location Demo
+
+A bubble-wrap demo to show how to use location API.
+

--- a/samples/location/Rakefile
+++ b/samples/location/Rakefile
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+$:.unshift("/Library/RubyMotion/lib")
+require 'motion/project'
+require 'bubble-wrap/location'
+require 'bubble-wrap/http'
+require 'bubble-wrap/core'
+
+Motion::Project::App.setup do |app|
+  app.name = 'location'
+end

--- a/samples/location/app/app_delegate.rb
+++ b/samples/location/app/app_delegate.rb
@@ -1,0 +1,8 @@
+class AppDelegate
+  def application(application, didFinishLaunchingWithOptions:launchOptions)
+    @window = UIWindow.alloc.initWithFrame(UIScreen.mainScreen.bounds)
+    places_list_controller = PlacesListController.alloc.init
+    @window.rootViewController = places_list_controller
+    @window.makeKeyAndVisible
+  end
+end

--- a/samples/location/app/controllers/image_list_controller.rb
+++ b/samples/location/app/controllers/image_list_controller.rb
@@ -1,0 +1,30 @@
+class PlacesListController < UITableViewController
+  attr_accessor :places_list
+
+  def viewDidLoad
+    @places_list = []
+    Places.load(self)
+    view.dataSource = view.delegate = self
+  end 
+
+  def viewWillAppear(animated)
+    view.reloadData
+  end
+
+  def tableView(tableView, numberOfRowsInSection:section)
+    @places_list.size
+  end
+
+  def reloadData
+    view.reloadData
+  end
+
+  CellID = 'CellIdentifier'
+  def tableView(tableView, cellForRowAtIndexPath:indexPath)
+    cell = tableView.dequeueReusableCellWithIdentifier(CellID) || UITableViewCell.alloc.initWithStyle(UITableViewCellStyleSubtitle, reuseIdentifier:CellID)
+    placeItem= @places_list[indexPath.row]
+    cell.textLabel.text = placeItem
+    cell
+  end
+
+end

--- a/samples/location/app/models/places.rb
+++ b/samples/location/app/models/places.rb
@@ -1,0 +1,15 @@
+class Places
+  API_KEY = ""
+  #See google places documentation at https://developers.google.com/places/documentation/ to obtain a key
+
+  def self.load(places_list_controller)
+    BW::Location.get do |result|
+      BW::Location.stop
+      BubbleWrap::HTTP.get("https://maps.googleapis.com/maps/api/place/search/json?location=#{result[:to].latitude},#{result[:to].longitude}&radius=500&sensor=false&key=#{API_KEY}") do |response|
+        names = BW::JSON.parse(response.body.to_str)["results"].map{|r| r["name"]}
+        places_list_controller.places_list = names  
+        places_list_controller.reloadData
+      end
+    end
+  end
+end

--- a/samples/location/spec/main_spec.rb
+++ b/samples/location/spec/main_spec.rb
@@ -1,0 +1,9 @@
+describe "Application 'google_location'" do
+  before do
+    @app = UIApplication.sharedApplication
+  end
+
+  it "has one window" do
+    @app.windows.size.should == 1
+  end
+end


### PR DESCRIPTION
Adding a bubble-wrap sample that uses the location wrapper.  It also uses the bubble-wrap HTTP wrapper and JSON parsing.

The sample is a simple application that gets the user's location, uses the google places api to get the nearest places and displays the places in a list view.

Because it uses the google places API, the user will need to enter their own google API key in app/models/places.rb for the places to display in the list view.
