### PR TITLE
Added the ability to perform requests without the http:// scheme

### DIFF
--- a/motion/http.rb
+++ b/motion/http.rb
@@ -306,11 +306,20 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
       end
 
       def create_url(url_string)
+        uri = handle_http_prefix(url_string)
         if (@method == "GET" || @method == "HEAD") && @payload
           convert_payload_to_url if @payload.is_a?(Hash)
-          url_string += "?#{@payload}"
+          uri += "?#{@payload}"
         end
-        NSURL.URLWithString(url_string.stringByAddingPercentEscapesUsingEncoding NSUTF8StringEncoding)
+        NSURL.URLWithString(uri.stringByAddingPercentEscapesUsingEncoding NSUTF8StringEncoding)
+      end
+
+      def handle_http_prefix(url_string)
+        if url_string =~ /^http[s]?:\/\//
+          url_string
+        else
+          "http://#{url_string}"
+        end
       end
 
       def convert_payload_to_url

--- a/spec/motion/http_spec.rb
+++ b/spec/motion/http_spec.rb
@@ -148,6 +148,11 @@ describe "HTTP" do
         @query.method.should.equal "GET"
       end
 
+      it "should handle requests with or without the http(s):// prefix" do
+        short_query = BW::HTTP::Query.new( 'fakeh.ost' , :post )
+        short_query.request.URL.description.should.equal 'http://fakeh.ost'
+      end
+
       it "should set the deleted delegator from options" do
         @query.instance_variable_get(:@delegator).should.equal @action
         @options.should.not.has_key? :action


### PR DESCRIPTION
@mattetti @clayallsopp @jamesotron  What do you think of this feature?
Didn't want to push into master before others agree with it.

Basically - it adds the ability to fire requests with `bubblewrap.io` as well as `http://bubblewrap.io`.
