### PR TITLE
Properly identify https as a valid URL prefix

### DIFF
--- a/motion/http.rb
+++ b/motion/http.rb
@@ -315,7 +315,7 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
       end
 
       def validate_url_prefix(url_string)
-        if (url_string =~ /^\w{3,4}:\/\//).nil?
+        if (url_string =~ /^\w{4,5}:\/\//).nil?
           raise URLPrefixError, "No URL scheme provided (http://, https:// or similar)."
         end
       end

--- a/spec/motion/http_spec.rb
+++ b/spec/motion/http_spec.rb
@@ -154,6 +154,12 @@ describe "HTTP" do
             BW::HTTP::Query.new( 'arest.us' , :get ) { |r| p r.body.to_str }
           }.should.raise URLPrefixError
       end
+      
+      it "should identify https:// as a valid URL similar scheme" do
+        lambda {
+            BW::HTTP::Query.new( 'https://foo.bar' , :get ) { |r| p r.body.to_str }
+          }.should.not.raise URLPrefixError
+      end
 
       it "should set the deleted delegator from options" do
         @query.instance_variable_get(:@delegator).should.equal @action


### PR DESCRIPTION
The `validate_url_prefix` method for BubbleWrap::HTTP was looking to match a regexp of `/^\w{3,4}:\/\//`, which matches `http://`, but not `https://` (because `https` is five letters, not 3 or 4). This pull request fixes and adds a demonstrative test - this test fails on master, but passes with this change.
