### PR TITLE
Made the camelCase methods snake_case

### DIFF
--- a/motion/ui/gestures.rb
+++ b/motion/ui/gestures.rb
@@ -26,6 +26,39 @@ class UIView
     add_gesture_recognizer_helper(UILongPressGestureRecognizer.alloc.initWithTarget(self, action:'handle_gesture:'), enableInteraction, proc)
   end
 
+
+  def whenTapped(enableInteraction=true, &proc)
+    NSLog "[DEPRECATED - whenTapped] please use when_tapped instead."
+    when_tapped(enableInteraction, &proc)
+  end
+
+  def whenPinched(enableInteraction=true, &proc)
+    NSLog "[DEPRECATED - whenPinched] please use when_pinched instead."
+    when_pinched(enableInteraction, &proc)
+  end
+
+  def whenRotated(enableInteraction=true, &proc)
+    NSLog "[DEPRECATED - whenRotated] please use when_rotated instead."
+    when_rotated(enableInteraction, &proc)
+  end
+
+  def whenSwiped(enableInteraction=true, &proc)
+    NSLog "[DEPRECATED - whenSwiped] please use when_swiped instead."
+    when_swiped(enableInteraction, &proc)
+  end
+
+  def whenPanned(enableInteraction=true, &proc)
+    NSLog "[DEPRECATED - whenPanned] please use when_panned instead."
+    when_panned(enableInteraction, &proc)
+  end
+
+  def whenPressed(enableInteraction=true, &proc)
+    NSLog "[DEPRECATED - whenPressed] please use when_pressed instead."
+    when_pressed(enableInteraction, &proc)
+  end
+
+
+
   private
 
   def handle_gesture(recognizer)

--- a/spec/motion/core/gestures_spec.rb
+++ b/spec/motion/core/gestures_spec.rb
@@ -31,26 +31,32 @@ describe UIView do
 
   describe '#when_tapped' do
     testMethod.call :when_tapped
+    testMethod.call :whenTapped
   end
 
   describe '#when_pinched' do
     testMethod.call :when_pinched
+    testMethod.call :whenPinched
   end
 
   describe '#when_rotated' do
     testMethod.call :when_rotated
+    testMethod.call :whenRotated
   end
   
   describe '#when_swiped' do
     testMethod.call :when_swiped
+    testMethod.call :whenSwiped
   end
 
   describe '#when_panned' do
     testMethod.call :when_panned
+    testMethod.call :whenPanned
   end
 
   describe '#when_pressed' do
     testMethod.call :when_pressed
+    testMethod.call :whenPressed
   end
 
 end


### PR DESCRIPTION
This probably shouldn't be merged into master, because it'll break lots of projects.

What I'm proposing is that we merge it into 1.5 or 2.0 release.

This is the only wrapper that uses camelCase method names, and it would be great if we could stick to the snake_case only.
