### PR TITLE
RSSParser should parse asynchronously

### DIFF
--- a/motion/rss_parser.rb
+++ b/motion/rss_parser.rb
@@ -145,7 +145,11 @@ module BubbleWrap
     def fetch_source_data(&blk)
       if @source.is_a?(NSURL)
         HTTP.get(@source.absoluteString) do |response|
-          blk.call(response.body) if response.ok?
+          if response.ok?
+            blk.call(response.body)
+          else
+            parser(parser, parseErrorOccured:"HTTP request failed (#{response})")
+          end
         end
       else
         yield @source


### PR DESCRIPTION
`RSSParser` now fetches the source data with `BW::HTTP` instead of using `NSXMLParser`'s `initWithContentsOfURL:`, which is synchronous.

Specs are missing. Ideas for clever spec'ing very welcome!

Fixes #135.
