### PR TITLE
added a shorthand for this nasty method

### DIFF
--- a/motion/core/string.rb
+++ b/motion/core/string.rb
@@ -33,12 +33,12 @@ module BubbleWrap
       word
     end
 
-    def utf8_encoded
-      stringByAddingPercentEscapesUsingEncoding NSUTF8StringEncoding
+    def to_url_encoded(encoding = NSUTF8StringEncoding)
+      stringByAddingPercentEscapesUsingEncoding encoding
     end
 
-    def utf8_decoded
-      stringByReplacingPercentEscapesUsingEncoding NSUTF8StringEncoding
+    def to_url_decoded(encoding = NSUTF8StringEncoding)
+      stringByReplacingPercentEscapesUsingEncoding encoding
     end
 
     def to_color

--- a/spec/motion/core/string_spec.rb
+++ b/spec/motion/core/string_spec.rb
@@ -146,18 +146,25 @@ describe BubbleWrap::String do
 
   describe "stringByAddingPercentEscapesUsingEncoding and reverse" do
 
-    it "utf8_encoded" do
+    it "to_url_encoded" do
       string = "hey ho let's {go}"
       real_encoded = string.stringByAddingPercentEscapesUsingEncoding NSUTF8StringEncoding
 
-      string.utf8_encoded.should.equal real_encoded
+      string.to_url_encoded.should.equal real_encoded
     end
 
-    it "utf8_decoded" do
+    it "to_url_decoded" do
       string = "hey%20ho%20let's%20%7Bgo%7D"
       real_decoded = string.stringByReplacingPercentEscapesUsingEncoding NSUTF8StringEncoding
       
-      string.utf8_decoded.should.equal real_decoded
+      string.to_url_decoded.should.equal real_decoded
+    end
+
+    it "handles other encodings" do
+      string = "hey ho let's {go}"
+      utf16 = string.stringByAddingPercentEscapesUsingEncoding NSUTF16StringEncoding
+      
+      string.to_url_encoded(NSUTF16StringEncoding).should.equal utf16
     end
 
   end


### PR DESCRIPTION
This method is hard to type/find even in the XCode :)

For me, `#utf8_encoded` and `#utf8_decoded` sounds logically.
Maybe you'll have a better name for it.
