### PR TITLE
fix crash when http header contains nil value

### DIFF
--- a/motion/http.rb
+++ b/motion/http.rb
@@ -360,7 +360,7 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
         return nil if hash.nil?
         escaped_hash = {}
 
-        hash.each{|k,v| escaped_hash[k] = v.gsub("\n", CLRF) }
+        hash.each{|k,v| escaped_hash[k] = v.gsub("\n", CLRF) if v }
         escaped_hash
       end
 

--- a/spec/motion/http_spec.rb
+++ b/spec/motion/http_spec.rb
@@ -147,6 +147,15 @@ describe "HTTP" do
       @query.should.respond_to :options
     end
 
+    it "should accept nil header value" do
+      @headers = { 'Authorization' => nil, 'User-Agent' => "Mozilla/5.0 (X11; Linux x86_64; rv:12.0) \n Gecko/20100101 Firefox/12.0" }
+      @options = {
+        headers: @headers,
+      }
+      @query = BubbleWrap::HTTP::Query.new( @localhost_url , :get, @options )
+      @query.should.not.be.nil
+    end
+
     describe "When initialized" do
 
       it "should upcase the HTTP method" do


### PR DESCRIPTION
as per https://github.com/rubymotion/BubbleWrap/commit/eb7fe41affe20d77ca48b7b9a2f92cb053dfed90#commitcomment-1846996
