### PR TITLE
add the `_spec' into App.identifier

### DIFF
--- a/spec/motion/core/app_spec.rb
+++ b/spec/motion/core/app_spec.rb
@@ -153,7 +153,7 @@ describe BubbleWrap::App do
 
   describe '.identifier' do
     it 'returns the application identifier' do
-      App.identifier.should == 'io.bubblewrap.testSuite'
+      App.identifier.should == 'io.bubblewrap.testSuite_spec'
     end
   end
 


### PR DESCRIPTION
Since RubyMotion v1.24, `_spec' is added into Application identifier when will run`rake spec'.
