### PR TITLE
Adds App.window

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Other available methods:
 * `App.frame`
 * `App.delegate`
 * `App.shared`
+* `App.window`
 * `App.current_locale`
 
 

--- a/motion/core/app.rb
+++ b/motion/core/app.rb
@@ -114,6 +114,11 @@ module BubbleWrap
       UIApplication.sharedApplication
     end
 
+    # the Application Window
+    def window
+      UIApplication.sharedApplication.keyWindow || UIApplication.sharedApplication.windows[0]
+    end
+
     # @return [NSLocale] locale of user settings
     def current_locale
       languages = NSLocale.preferredLanguages

--- a/motion/core/device/camera.rb
+++ b/motion/core/device/camera.rb
@@ -117,7 +117,7 @@ module BubbleWrap
           self.picker.cameraDevice = camera_device
         end
 
-        presenting_controller ||= UIApplication.sharedApplication.keyWindow.rootViewController
+        presenting_controller ||= App.window.rootViewController
         presenting_controller.presentViewController(self.picker, animated:@options[:animated], completion: lambda {})
       end
 

--- a/motion/media/player.rb
+++ b/motion/media/player.rb
@@ -87,7 +87,7 @@ module BubbleWrap
 
         if display_modal
           @presenting_controller = options[:controller]
-          @presenting_controller ||= UIApplication.sharedApplication.keyWindow.rootViewController
+          @presenting_controller ||= App.window.rootViewController
           @presenting_controller.presentMoviePlayerViewControllerAnimated(@media_player)
         else
           if block.nil?

--- a/spec/motion/media/player_spec.rb
+++ b/spec/motion/media/player_spec.rb
@@ -36,7 +36,7 @@ describe BubbleWrap::Media::Player do
     end
 
     it "should present a modalViewController on root if no controller given" do
-      @controller = UIApplication.sharedApplication.keyWindow.rootViewController
+      @controller = App.window.rootViewController
 
       @player.play_modal(@local_file)
 
@@ -58,7 +58,7 @@ describe BubbleWrap::Media::Player do
       # .presentMoviePlayerViewControllerAnimated detects whether or not
       # @controller.view is part of a hierarchy, I guess. if you remove this
       # then the test fails.
-      UIApplication.sharedApplication.keyWindow.rootViewController.view.addSubview(@controller.view)
+      App.window.rootViewController.view.addSubview(@controller.view)
 
       @player.play_modal(@local_file, controller: @controller)
 


### PR DESCRIPTION
another global accessor, like `App.shared` and `App.delegate`.  Updated code to use this shortcut, since it attempts to fix the rare case when `sharedApplication.keyWindow` does not resolve to a `UIWindow` (because `makeKeyAndVisible` has not been called)
