### PR TITLE
escape values and keys when creating query string from payload #160

### DIFF
--- a/motion/http.rb
+++ b/motion/http.rb
@@ -286,11 +286,12 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
       end
 
       def create_url(url_string)
+        url_string = url_string.stringByAddingPercentEscapesUsingEncoding NSUTF8StringEncoding
         if (@method == "GET" || @method == "HEAD") && @payload
           convert_payload_to_url if @payload.is_a?(Hash)
           url_string += "?#{@payload}"
         end
-        url = NSURL.URLWithString(url_string.stringByAddingPercentEscapesUsingEncoding NSUTF8StringEncoding)
+        url = NSURL.URLWithString(url_string)
 
         validate_url(url)
         url
@@ -302,9 +303,15 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
         end
       end
 
+      def escape(string)
+        if string
+          CFURLCreateStringByAddingPercentEscapes nil, string, "[]", ";=&,", KCFStringEncodingUTF8
+        end
+      end
+
       def convert_payload_to_url
         params_array = process_payload_hash(@payload)
-        params_array.map! { |key, value| "#{key}=#{value}" }
+        params_array.map! { |key, value| "#{escape key}=#{escape value}" }
         @payload = params_array.join("&")
       end
 

--- a/spec/motion/http_spec.rb
+++ b/spec/motion/http_spec.rb
@@ -620,6 +620,21 @@ describe "HTTP" do
 
     end
 
+    describe "properly format payload to url get query string" do
+
+      before do
+        @payload = {"we love" => '#==Rock&Roll==#', "radio" => "Ga Ga"}
+        @url_string = 'http://fake.url/method'
+        @get_query = BubbleWrap::HTTP::Query.new( @url_string, :get, :payload => @payload)
+        @escaped_url = "http://fake.url/method?we%20love=%23%3D%3DRock%26Roll%3D%3D%23&radio=Ga%20Ga"
+      end
+
+      it "should escape \#=& characters only in keys and values" do
+        @get_query.instance_variable_get(:@url).description.should.equal @escaped_url
+      end
+
+    end
+
     class FakeSender
       attr_reader :challenge, :credential, :was_cancelled
       def cancelAuthenticationChallenge(challenge)


### PR DESCRIPTION
This solution doesn't break current implementation. Specs are included.
