### PR TITLE
coerce converted Hash payload keys/values to strings, fixes bug introduced in #161

### DIFF
--- a/motion/http.rb
+++ b/motion/http.rb
@@ -305,7 +305,7 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
 
       def escape(string)
         if string
-          CFURLCreateStringByAddingPercentEscapes nil, string, "[]", ";=&,", KCFStringEncodingUTF8
+          CFURLCreateStringByAddingPercentEscapes nil, string.to_s, "[]", ";=&,", KCFStringEncodingUTF8
         end
       end
 

--- a/spec/motion/http_spec.rb
+++ b/spec/motion/http_spec.rb
@@ -623,10 +623,10 @@ describe "HTTP" do
     describe "properly format payload to url get query string" do
 
       before do
-        @payload = {"we love" => '#==Rock&Roll==#', "radio" => "Ga Ga"}
+        @payload = {"we love" => '#==Rock&Roll==#', "radio" => "Ga Ga", "qual" => 3.0, "incr" => -1}
         @url_string = 'http://fake.url/method'
         @get_query = BubbleWrap::HTTP::Query.new( @url_string, :get, :payload => @payload)
-        @escaped_url = "http://fake.url/method?we%20love=%23%3D%3DRock%26Roll%3D%3D%23&radio=Ga%20Ga"
+        @escaped_url = "http://fake.url/method?we%20love=%23%3D%3DRock%26Roll%3D%3D%23&radio=Ga%20Ga&qual=3.0&incr=-1"
       end
 
       it "should escape \#=& characters only in keys and values" do


### PR DESCRIPTION
Query#convert_payload_to_url should allow non-String values in converted hashes.
