### PR TITLE
new :query option appends url query string to requests with any http method (GET, POST, PUT, ...)

### DIFF
--- a/motion/http.rb
+++ b/motion/http.rb
@@ -81,6 +81,7 @@ module BubbleWrap
       # options<Hash>:: optional options used for the query
       #
       # ==== Options
+      # :query             - String or Hash to append to url resource as query string.
       # :payload<String>   - data to pass to a POST, PUT, DELETE query.
       # :action            - Proc, class or object to call when the file is downloaded.
       # a proc will receive a Response object while the passed object
@@ -91,6 +92,7 @@ module BubbleWrap
       def initialize(url_string, http_method = :get, options={})
         @method = http_method.upcase.to_s
         @delegator = options.delete(:action) || self
+        @query = options.delete(:query)
         @payload = options.delete(:payload)
         @files = options.delete(:files)
         @boundary = options.delete(:boundary) || BW.create_uuid
@@ -287,10 +289,11 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
 
       def create_url(url_string)
         url_string = url_string.stringByAddingPercentEscapesUsingEncoding NSUTF8StringEncoding
-        if (@method == "GET" || @method == "HEAD") && @payload
-          convert_payload_to_url if @payload.is_a?(Hash)
-          url_string += "?#{@payload}"
+        if @method == "GET" || @method == "HEAD"
+          @query ||= @payload
         end
+        convert_query_to_url if @query.is_a?(Hash)
+        url_string += "?#{@query}" if @query
         url = NSURL.URLWithString(url_string)
 
         validate_url(url)
@@ -309,10 +312,10 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
         end
       end
 
-      def convert_payload_to_url
-        params_array = process_payload_hash(@payload)
+      def convert_query_to_url
+        params_array = process_payload_hash(@query)
         params_array.map! { |key, value| "#{escape key}=#{escape value}" }
-        @payload = params_array.join("&")
+        @query = params_array.join("&")
       end
 
       def process_payload_hash(payload, prefix=nil)

--- a/spec/motion/http_spec.rb
+++ b/spec/motion/http_spec.rb
@@ -216,15 +216,31 @@ describe "HTTP" do
           "twitter:@mneorr".dataUsingEncoding NSUTF8StringEncoding
         end
 
-        it "should set payload from options{} to @payload" do
+        it "should set payload from options{} to @query on GET request" do
           payload = "user[name]=marin&user[surname]=usalj&twitter=@mneorr&website=mneorr.com&values[]=apple&values[]=orange&values[]=peach&credentials[username]=mneorr&credentials[password]=123456xx!@crazy"
-          @query.instance_variable_get(:@payload).should.equal payload
+          @query.instance_variable_get(:@query).should.equal payload
           @options.should.not.has_key? :payload
+        end
+
+        it "should set query from options{} to @query on GET request" do
+          query_string_query = BubbleWrap::HTTP::Query.new( @fake_url , :get,  { query: {name: "apple", model: "macbook"}} )
+          query_string_query.instance_variable_get(:@query).should.equal 'name=apple&model=macbook'
+          query_string_query.instance_variable_get(:@options).should.not.has_key? :query
+          query_string_query.instance_variable_get(:@url).description.should.equal "#{@fake_url}?name=apple&model=macbook"
+        end
+
+        it "should set query and payload from options{} to @query and @pyaload on POST" do
+          query_string_query = BubbleWrap::HTTP::Query.new( @fake_url , :post,  { query: {name: "apple", model: "macbook"}, payload: "data"} )
+          query_string_query.instance_variable_get(:@query).should.equal 'name=apple&model=macbook'
+          query_string_query.instance_variable_get(:@payload).should.equal 'data'
+          query_string_query.instance_variable_get(:@options).should.not.has_key? :query
+          query_string_query.instance_variable_get(:@options).should.not.has_key? :payload
+          query_string_query.instance_variable_get(:@url).description.should.equal "#{@fake_url}?name=apple&model=macbook"
         end
 
         it "should check if @payload is a hash before generating GET params" do
           query_string_payload = BubbleWrap::HTTP::Query.new( @fake_url , :get,  { payload: "name=apple&model=macbook"} )
-          query_string_payload.instance_variable_get(:@payload).should.equal 'name=apple&model=macbook'
+          query_string_payload.instance_variable_get(:@query).should.equal 'name=apple&model=macbook'
         end
 
         it "should check if payload is nil" do


### PR DESCRIPTION
It wasn't possible to add an url query string to other than GET/HEAD requests.

This update preserves original `:payload` option (works same as before), additionally there is a new option `:query` which adds an url query string to requests with any http method.

Because now `:payload` and `:query` options has the same meaning for GET/HEAD requests, the `:query` option has a precedence before `:payload`.
- fixes Query.new docs (:delegator -> :action)
