### PR TITLE
BW::HTTP get 401 status in response instead of  `NSURLErrorDomain -1012` error message

### DIFF
--- a/motion/http.rb
+++ b/motion/http.rb
@@ -175,9 +175,14 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
 
       def connection(connection, didReceiveAuthenticationChallenge:challenge)
         if (challenge.previousFailureCount == 0)
-          new_credential = NSURLCredential.credentialWithUser(credentials[:username], password:credentials[:password], persistence:NSURLCredentialPersistenceForSession)
-          challenge.sender.useCredential(new_credential, forAuthenticationChallenge:challenge)
-          log "auth challenged, answered with credentials: #{credentials.inspect}"
+          if credentials[:username].to_s.empty? && credentials[:password].to_s.empty?
+            challenge.sender.continueWithoutCredentialForAuthenticationChallenge(challenge)
+            log 'Continue without credentials to get 401 status in response'
+          else
+            new_credential = NSURLCredential.credentialWithUser(credentials[:username], password:credentials[:password], persistence:NSURLCredentialPersistenceForSession)
+            challenge.sender.useCredential(new_credential, forAuthenticationChallenge:challenge)
+            log "auth challenged, answered with credentials: #{credentials.inspect}"
+          end
         else
           challenge.sender.cancelAuthenticationChallenge(challenge)
           log 'Auth Failed :('

--- a/spec/motion/http_spec.rb
+++ b/spec/motion/http_spec.rb
@@ -618,6 +618,12 @@ describe "HTTP" do
         @challenge.sender.credential.persistence.should.equal NSURLCredentialPersistenceForSession
       end
 
+      it 'should continue without credentials when no credentials provided' do
+        @options.delete :credentials
+        @query = BubbleWrap::HTTP::Query.new( @localhost_url , :get, @options )
+        @query.connection(nil, didReceiveAuthenticationChallenge:@challenge)
+        @challenge.sender.continue_without_credential.should.equal true
+      end
     end
 
     describe "properly format payload to url get query string" do
@@ -636,13 +642,19 @@ describe "HTTP" do
     end
 
     class FakeSender
-      attr_reader :challenge, :credential, :was_cancelled
+      attr_reader :challenge, :credential, :was_cancelled, :continue_without_credential
+
       def cancelAuthenticationChallenge(challenge)
         @was_cancelled = true
       end
+
       def useCredential(credential, forAuthenticationChallenge:challenge)
         @challenge = challenge
         @credential = credential
+      end
+
+      def continueWithoutCredentialForAuthenticationChallenge(challenge)
+        @continue_without_credential = true
       end
     end
 


### PR DESCRIPTION
If no credentials provided for BW::HTTP::Query, in delegate method `connection:didReceiveAuthenticationChallenge:` we should continue without credentials to let user get HTTP 401 status properly, instead of a `NSURLErrorDomain -1012` error message.

Actually I'm also thinking about use `continueWithoutCredentialForAuthenticationChallenge` instead of `cancelAuthenticationChallenge` when `previousFailureCount > 0`, to ensure user get 401 response when request with incorrect credentials. But this change looks a bit aggressive, so I would like to discuss with you.
