### PR TITLE
Fixed side navigation overlapping on shorter browsers (under 780 pixels height)

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -235,6 +235,14 @@ footer img {
   }
 }
 
+@media print, screen and (max-height: 780px) {
+  footer {
+    top: 400px;
+    float:none;
+    bottom:inherit;
+  }
+}
+
 @media print, screen and (max-width: 720px) {
   body {
     word-wrap:break-word;


### PR DESCRIPTION
The website has an overlap on the left navigation which makes it unusable. I added a simple CSS fix to resolve this issue.

![](https://s3.amazonaws.com/files.droplr.com/files_production/acc_68324/dhf5?AWSAccessKeyId=AKIAJSVQN3Z4K7MT5U2A&Expires=1352411866&Signature=WFcErOAU7KcevKrMWvOth61nt5E%3D&response-content-disposition=inline%3B%20filename%2A%3DUTF-8%27%27Screenshot%2B2012-11-08%2Bat%2B13.45.35.png)
