### PR TITLE
The expression "App::Persistent[key] = value" should return value, instead of boolean.

### DIFF
--- a/motion/core/persistence.rb
+++ b/motion/core/persistence.rb
@@ -10,6 +10,7 @@ module BubbleWrap
     def []=(key, value)
       storage.setObject(value, forKey: storage_key(key))
       storage.synchronize
+      self[key]
     end
 
     def [](key)


### PR DESCRIPTION
For example

``` ruby
def nonce(refresh = false)
  App::Persistent[:nonce] = nil if refresh
  App::Persistence[:nonce] ||= NSUUID.UUID.UUIDString
end

App::Persistence[:nonce] # => nil
nonce # => true (String expected)
nonce # => "96FC8AAA-E1F2-4919-9D64-D189B771258D" (as expected)
nonce(:refresh) # => true (String expected)
```
