### PR TITLE
Camera now works with -presentedViewController

### DIFF
--- a/motion/core/device/camera.rb
+++ b/motion/core/device/camera.rb
@@ -117,6 +117,7 @@ module BubbleWrap
           self.picker.cameraDevice = camera_device
         end
 
+        presenting_controller ||= App.window.rootViewController.presentedViewController # May be nil, but handles use case of container views
         presenting_controller ||= App.window.rootViewController
         presenting_controller.presentViewController(self.picker, animated:@options[:animated], completion: lambda {})
       end


### PR DESCRIPTION
Referenced from https://github.com/clayallsopp/formotion/pull/57#issuecomment-11560208

This intelligently picks the appropriate view controller to present the `UIImagePickerViewController` from
