### PR TITLE
Allow periodic timers to be scheduled in the "common modes" of a runloop

### DIFF
--- a/motion/reactor.rb
+++ b/motion/reactor.rb
@@ -37,17 +37,14 @@ module BubbleWrap
     # Call `callback` or the passed block every `interval` seconds.
     # Returns a timer signature that can be passed into
     # `cancel_timer`
-    # Pass :common_modes => true in the options hash to schedule the timer
+    # Optionally supply a callback as a second argument instead of a block
+    # (as per EventMachine API)
+    # Optionally supply :common_modes => true in args to schedule the timer
     # for the runloop "common modes" (NSRunLoopCommonModes) instead of
-    # the default mode.
-    # You may pass :callback => an_object_that_responds_to_call in the 
-    # options hash instead of supplying a block
-    # "options" may also itself respond to call, which preserves the behaviour
-    # of version 1.1.5 of this gem
-    def add_periodic_timer(interval, options={}, &blk)
-      options = {:callback => options} if options.respond_to?(:call)
+    # the default runloop mode.
+    def add_periodic_timer(interval, *args, &blk)
       @timers ||= {}
-      timer = PeriodicTimer.new(interval,options,&blk)
+      timer = PeriodicTimer.new(interval,*args,&blk)
       timer.on(:cancelled) do
         @timers.delete(timer)
       end

--- a/motion/reactor/periodic_timer.rb
+++ b/motion/reactor/periodic_timer.rb
@@ -7,11 +7,14 @@ module BubbleWrap
       attr_accessor :interval
 
       # Create a new timer that fires after a given number of seconds
-      def initialize(interval, options={}, &blk)
-        options = {:callback => options} if options.respond_to?(:call)
+      def initialize(interval, *args, &blk)
+        options = args.last.is_a?(Hash) ? args.last : {}
+        callback = args.first.respond_to?(:call) ? args.first : blk
+        raise ArgumentError, "No callback or block supplied to periodic timer" unless callback
+
         self.interval = interval
         fire = proc {
-          (options[:callback] || blk).call
+          callback.call
           trigger(:fired)
         }
         @timer = NSTimer.timerWithTimeInterval(interval, target: fire, selector: 'call:', userInfo: nil, repeats: true)

--- a/spec/motion/reactor_spec.rb
+++ b/spec/motion/reactor_spec.rb
@@ -54,30 +54,7 @@ describe BubbleWrap::Reactor do
       end
     end
 
-    it 'runs callbacks repeatedly in common runloop modes' do
-      @proxy.proof = 0
-      @timer = @subject.add_periodic_timer 0.5, :common_modes => true do
-        @proxy.proof = @proxy.proof + 1
-        @subject.cancel_timer(@timer) if @proxy.proof > 2
-      end
-      wait 1.1 do
-        @proxy.proof.should >= 2
-      end
-    end
-
     it 'accepts non-block callbacks' do
-      @proxy.proof = 0
-      callback = lambda {
-        @proxy.proof = @proxy.proof + 1
-        @subject.cancel_timer(@timer) if @proxy.proof > 2
-      }
-      @timer = @subject.add_periodic_timer 0.5, :callback => callback
-      wait 1.1 do
-        @proxy.proof.should >= 2
-      end
-    end
-
-    it 'accepts non-block callbacks in place of options (old-style API)' do
       @proxy.proof = 0
       callback = lambda {
         @proxy.proof = @proxy.proof + 1
@@ -89,6 +66,16 @@ describe BubbleWrap::Reactor do
       end
     end
 
+    it 'runs callbacks repeatedly in common runloop modes' do
+      @proxy.proof = 0
+      @timer = @subject.add_periodic_timer 0.5, :common_modes => true do
+        @proxy.proof = @proxy.proof + 1
+        @subject.cancel_timer(@timer) if @proxy.proof > 2
+      end
+      wait 1.1 do
+        @proxy.proof.should >= 2
+      end
+    end
   end
 
   describe '.cancel_timer' do


### PR DESCRIPTION
A UIScrollView was preventing my BubbleWrap::Reactor::PeriodicTimer from firing. http://stackoverflow.com/a/2742275 points at the solution - the timer can be scheduled to fire in the common modes of the runloop, rather than the default.

I tried to enable this in an additive way - without changing the default scheduling of BubbleWrap timers and also leaving the existing implementation of EventMachine APIs intact. Ruby is apparently happy to insert an options hash at the end of a (splat) args array when required, so I can use *args to collect both an optional proc/lambda for the callback and any options.

So

``` ruby
def add_periodic_timer(interval, callback=nil, &blk)
```

became

``` ruby
def add_periodic_timer(interval, *args, &blk)
```

Simply adding an options = {} argument

``` ruby
def add_periodic_timer(interval, callback=nil, options = {}, &blk)
```

did not result in the correct behaviour when :common_modes => true is supplied, but the callback is not.
