### PR TITLE
fixed a typo in readme.md for the rss section

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ state callbacks:
 ```ruby
 feed_parser = BW::RSSParser.new("http://feeds.feedburner.com/sdrbpodcast")
 feed_parser.delegate = self
-feed.parse do |item|
+feed_parser.parse do |item|
   p item.title
 end
 


### PR DESCRIPTION
The variable name in the RSS section had a typo where feed_parser was mentioned as feed
