### PR TITLE
Add init wrappers for UIBarButtonItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,109 @@ button.when(UIControlEventTouchUpInside) do
 end
 ```
 
+### UIBarButtonItem
+
+`BW::UIBarButtonItem` provides an idiomatic Ruby syntax for instantiating `UIBarButtonItem` objects.  Instead of a target-action pair, each method accepts a block.  When the button is tapped, the block is executed.  As a convenience, the block is optional.
+
+```ruby
+BW::UIBarButtonItem.system(:save) do
+  # ...
+end
+
+title = "Friends"
+BW::UIBarButtonItem.styled(:plain, title) do
+  # ...
+end
+
+image = UIImage.alloc.init
+BW::UIBarButtonItem.styled(:bordered, image) do
+  # ...
+end
+
+image     = UIImage.alloc.init
+landscape = UIImage.alloc.init
+BW::UIBarButtonItem.styled(:bordered, image, landscape) do
+  # ...
+end
+
+view = UIView.alloc.init
+BW::UIBarButtonItem.custom(view) do
+  # ...
+end
+# NOTE: The block is attached to the view as a single tap gesture recognizer.
+```
+
+Alternatively, `BW::UIBarButtonItem` provides a flexible, builder-style syntax for dynamically instantiating `UIBarButtonItem` objects.
+
+```ruby
+options = { :system => :save }
+BW::UIBarButtonItem.build(options) do
+  # ...
+end
+
+options = { :styled => :plain, :title => "Friends" }
+BW::UIBarButtonItem.build(options) do
+  # ...
+end
+
+options = { :styled => :bordered, :image => UIImage.alloc.init }
+BW::UIBarButtonItem.build(options) do
+  # ...
+end
+
+options = {
+  :styled    => :bordered,
+  :image     => UIImage.alloc.init,
+  :landscape => UIImage.alloc.init
+}
+BW::UIBarButtonItem.build(options) do
+  # ...
+end
+
+options = { :custom => UIView.alloc.init }
+BW::UIBarButtonItem.build(options) do
+  # ...
+end
+# NOTE: The block is attached to the view as a single tap gesture recognizer.
+```
+
+The `.styled` button types are:
+
+```ruby
+:plain
+:bordered
+:done
+```
+
+And the `.system` button types are:
+
+```ruby
+:done
+:cancel
+:edit
+:save
+:add
+:flexible_space
+:fixed_space
+:compose
+:reply
+:action
+:organize
+:bookmarks
+:search
+:refresh
+:stop
+:camera
+:trash
+:play
+:pause
+:rewind
+:fast_forward
+:undo
+:redo
+:page_curl
+```
+
 ## HTTP
 
 `BW::HTTP` wraps `NSURLRequest`, `NSURLConnection` and friends to provide Ruby developers with a more familiar and easier to use API.

--- a/motion/ui/ui_bar_button_item.rb
+++ b/motion/ui/ui_bar_button_item.rb
@@ -1,0 +1,99 @@
+module BW
+  module UIBarButtonItem
+    module_function
+
+    def styled(type, *objects, &block)
+      action = block ? :call : nil
+      object = objects.size == 1 ? objects.first : objects
+      style  = Constants.get("UIBarButtonItemStyle", type)
+
+      item = if object.is_a?(String)
+        ::UIBarButtonItem.alloc.initWithTitle(object,
+          style:style,
+          target:block,
+          action:action
+        )
+      elsif object.is_a?(UIImage)
+        ::UIBarButtonItem.alloc.initWithImage(object,
+          style:style,
+          target:block,
+          action:action
+        )
+      elsif object.is_a?(Array) && object.size == 2 && object.all? { |o| o.is_a?(UIImage) }
+        ::UIBarButtonItem.alloc.initWithImage(object[0],
+          landscapeImagePhone:object[1],
+          style:style,
+          target:block,
+          action:action
+        )
+      else
+        raise ArgumentError, "invalid object - #{object.inspect}"
+      end
+
+      item.instance_variable_set(:@target, block)
+      item
+    end
+
+    def system(type, &block)
+      action      = block ? :call : nil
+      system_item = Constants.get("UIBarButtonSystemItem", type)
+
+      item = ::UIBarButtonItem.alloc.initWithBarButtonSystemItem(system_item,
+        target:block,
+        action:action
+      )
+      item.instance_variable_set(:@target, block)
+      item
+    end
+
+    def custom(view, &block)
+      view.when_tapped(true, &block) if block
+      ::UIBarButtonItem.alloc.initWithCustomView(view)
+    end
+
+    def build(options = {}, &block)
+      if options[:styled]
+        args = options.values_at(:title, :image, :landscape).compact
+        return styled(options[:styled], *args, &block)
+      end
+
+      return system(options[:system], &block) if options[:system]
+
+      return custom(options[:custom], &block) if options[:custom]
+      return custom(options[:view],   &block) if options[:view]
+
+      raise ArgumentError, "invalid options - #{options.inspect}"
+    end
+  end
+
+  Constants.register(
+    UIBarButtonItemStylePlain,
+    UIBarButtonItemStyleBordered,
+    UIBarButtonItemStyleDone,
+
+    UIBarButtonSystemItemDone,
+    UIBarButtonSystemItemCancel,
+    UIBarButtonSystemItemEdit,
+    UIBarButtonSystemItemSave,
+    UIBarButtonSystemItemAdd,
+    UIBarButtonSystemItemFlexibleSpace,
+    UIBarButtonSystemItemFixedSpace,
+    UIBarButtonSystemItemCompose,
+    UIBarButtonSystemItemReply,
+    UIBarButtonSystemItemAction,
+    UIBarButtonSystemItemOrganize,
+    UIBarButtonSystemItemBookmarks,
+    UIBarButtonSystemItemSearch,
+    UIBarButtonSystemItemRefresh,
+    UIBarButtonSystemItemStop,
+    UIBarButtonSystemItemCamera,
+    UIBarButtonSystemItemTrash,
+    UIBarButtonSystemItemPlay,
+    UIBarButtonSystemItemPause,
+    UIBarButtonSystemItemRewind,
+    UIBarButtonSystemItemFastForward,
+    UIBarButtonSystemItemUndo,
+    UIBarButtonSystemItemRedo,
+    UIBarButtonSystemItemPageCurl,
+  )
+end

--- a/spec/motion/core/ui_bar_button_item_spec.rb
+++ b/spec/motion/core/ui_bar_button_item_spec.rb
@@ -1,0 +1,454 @@
+describe BW::UIBarButtonItem do
+  describe ".styled" do
+    describe "given an unknown style" do
+      it "raises an exception" do
+        exception = should.raise(NameError) { BW::UIBarButtonItem.styled(:unknown, "object") }
+        exception.message.should.equal("uninitialized constant Kernel::UIBarButtonItemStyleUnknown")
+      end
+    end
+
+    describe "given an invalid object" do
+      it "raises an exception" do
+        exception = should.raise(ArgumentError) { BW::UIBarButtonItem.styled(:plain, :object) }
+        exception.message.should.equal("invalid object - :object")
+      end
+    end
+
+    ###############################################################################################
+
+    describe "given a String object" do
+      before do
+        @object  = "Friends"
+        @target  = -> { true }
+        @subject = BW::UIBarButtonItem.styled(:plain, @object, &@target)
+      end
+
+      it "has the correct class" do
+        @subject.class.should.equal(UIBarButtonItem)
+      end
+
+      it "has the correct style" do
+        @subject.style.should.equal(UIBarButtonItemStylePlain)
+      end
+
+      it "has the correct title" do
+        @subject.title.should.equal(@object)
+      end
+
+      it "has the correct target" do
+        @subject.target.should.equal(@target)
+      end
+
+      it "has the correct action" do
+        @subject.action.should.equal(:call)
+      end
+    end
+
+    ###############################################################################################
+
+    describe "given a String object but no block" do
+      before do
+        @object  = "Friends"
+        @subject = BW::UIBarButtonItem.styled(:plain, @object)
+      end
+
+      it "has the correct class" do
+        @subject.class.should.equal(UIBarButtonItem)
+      end
+
+      it "has the correct style" do
+        @subject.style.should.equal(UIBarButtonItemStylePlain)
+      end
+
+      it "has the correct title" do
+        @subject.title.should.equal(@object)
+      end
+
+      it "has the correct target" do
+        @subject.target.should.equal(nil)
+      end
+
+      it "has the correct action" do
+        @subject.target.should.equal(nil)
+      end
+    end
+
+    ###############################################################################################
+
+    describe "given an UIImage object" do
+      before do
+        @object  = UIImage.alloc.init
+        @target  = -> { true }
+        @subject = BW::UIBarButtonItem.styled(:bordered, @object, &@target)
+      end
+
+      it "has the correct class" do
+        @subject.class.should.equal(UIBarButtonItem)
+      end
+
+      it "has the correct style" do
+        @subject.style.should.equal(UIBarButtonItemStyleBordered)
+      end
+
+      it "has the correct image" do
+        @subject.image.should.equal(@object)
+      end
+
+      it "has the correct target" do
+        @subject.target.should.equal(@target)
+      end
+
+      it "has the correct action" do
+        @subject.action.should.equal(:call)
+      end
+    end
+
+    ###############################################################################################
+
+    describe "given two UIImage objects" do
+      before do
+        @object1 = UIImage.alloc.init
+        @object2 = UIImage.alloc.init
+        @target  = -> { true }
+        @subject = BW::UIBarButtonItem.styled(:done, @object1, @object2, &@target)
+      end
+
+      it "has the correct class" do
+        @subject.class.should.equal(UIBarButtonItem)
+      end
+
+      it "has the correct style" do
+        @subject.style.should.equal(UIBarButtonItemStyleDone)
+      end
+
+      it "has the correct image" do
+        @subject.image.should.equal(@object1)
+      end
+
+      it "has the correct iPhone landscape image" do
+        @subject.landscapeImagePhone.should.equal(@object2)
+      end
+
+      it "has the correct target" do
+        @subject.target.should.equal(@target)
+      end
+
+      it "has the correct action" do
+        @subject.action.should.equal(:call)
+      end
+    end
+  end
+
+  #################################################################################################
+
+  describe ".system" do
+    describe "given an unknown system item" do
+      it "raises an exception" do
+        exception = should.raise(NameError) { BW::UIBarButtonItem.system(:unknown) }
+        exception.message.should.equal("uninitialized constant Kernel::UIBarButtonSystemItemUnknown")
+      end
+    end
+
+    ###############################################################################################
+
+    describe "given a system item" do
+      before do
+        @target  = -> { true }
+        @subject = BW::UIBarButtonItem.system(:save, &@target)
+      end
+
+      it "has the correct class" do
+        @subject.class.should.equal(UIBarButtonItem)
+      end
+
+      it "has the correct system item" do
+        # TIP: systemItem is an undocumented property
+        @subject.systemItem.should.equal(UIBarButtonSystemItemSave)
+      end
+
+      it "has the correct target" do
+        @subject.target.should.equal(@target)
+      end
+
+      it "has the correct action" do
+        @subject.action.should.equal(:call)
+      end
+    end
+
+    ###############################################################################################
+
+    describe "given a system item but no block" do
+      before do
+        @subject = BW::UIBarButtonItem.system(:save)
+      end
+
+      it "has the correct class" do
+        @subject.class.should.equal(UIBarButtonItem)
+      end
+
+      it "has the correct system item" do
+        @subject.systemItem.should.equal(UIBarButtonSystemItemSave)
+      end
+
+      it "has the correct target" do
+        @subject.target.should.equal(nil)
+      end
+
+      it "has the correct action" do
+        @subject.action.should.equal(nil)
+      end
+    end
+  end
+
+  #################################################################################################
+
+  describe ".custom" do
+    describe "given a custom view" do
+      before do
+        @view    = UIView.alloc.init
+        @target  = -> { true }
+        @subject = BW::UIBarButtonItem.custom(@view, &@target)
+      end
+
+      it "has the correct class" do
+        @subject.class.should.equal(UIBarButtonItem)
+      end
+
+      it "has a custom view" do
+        @subject.customView.should.equal(@view)
+      end
+
+      it "adds one, single tap gesture recognizer to the custom view" do
+        @view.gestureRecognizers.size.should.equal(1)
+        @view.gestureRecognizers.first.class.should.equal(UITapGestureRecognizer)
+        @view.gestureRecognizers.first.numberOfTapsRequired.should.equal(1)
+      end
+    end
+
+    ###############################################################################################
+
+    describe "given a custom view but no block" do
+      before do
+        @view    = UIView.alloc.init
+        @subject = BW::UIBarButtonItem.custom(@view)
+      end
+
+      it "has the correct class" do
+        @subject.class.should.equal(UIBarButtonItem)
+      end
+
+      it "has a custom view" do
+        @subject.customView.should.equal(@view)
+      end
+
+      it "adds no gesture recognizers to the custom view" do
+        @view.gestureRecognizers.should.equal(nil)
+      end
+    end
+  end
+
+  #################################################################################################
+
+  describe ".build" do
+    describe "not given options" do
+      it "raises an exception" do
+        exception = should.raise(ArgumentError) { BW::UIBarButtonItem.build }
+        exception.message.should.equal("invalid options - {}")
+      end
+    end
+
+    describe "given unknown options" do
+      it "raises an exception" do
+        exception = should.raise(ArgumentError) { BW::UIBarButtonItem.build(:unknown => true) }
+        exception.message.should.equal("invalid options - {:unknown=>true}")
+      end
+    end
+
+    describe "given incompatible options for a styled item" do
+      before do
+        @options = {
+          :styled => :bordered,
+          :title  => "Friends",
+          :image  => UIImage.alloc.init
+        }
+      end
+
+      it "raises an exception" do
+        exception = should.raise(ArgumentError) { BW::UIBarButtonItem.build(@options) }
+        exception.message.should.equal("invalid object - #{@options.values_at(:title, :image)}")
+      end
+    end
+
+    ###############################################################################################
+
+    describe "given options for a styled item with a title" do
+      before do
+        @options = { :styled => :plain, :title => "Friends" }
+        @target  = -> { true }
+        @subject = BW::UIBarButtonItem.build(@options, &@target)
+      end
+
+      it "has the correct class" do
+        @subject.class.should.equal(UIBarButtonItem)
+      end
+
+      it "has the correct style" do
+        @subject.style.should.equal(UIBarButtonItemStylePlain)
+      end
+
+      it "has the correct title" do
+        @subject.title.should.equal(@options[:title])
+      end
+
+      it "has the correct target" do
+        @subject.target.should.equal(@target)
+      end
+
+      it "has the correct action" do
+        @subject.action.should.equal(:call)
+      end
+    end
+
+    ###############################################################################################
+
+    describe "given options for a styled item with an image" do
+      before do
+        @options = { :styled => :bordered, :image => UIImage.alloc.init }
+        @target  = -> { true }
+        @subject = BW::UIBarButtonItem.build(@options, &@target)
+      end
+
+      it "has the correct class" do
+        @subject.class.should.equal(UIBarButtonItem)
+      end
+
+      it "has the correct style" do
+        @subject.style.should.equal(UIBarButtonItemStyleBordered)
+      end
+
+      it "has the correct image" do
+        @subject.image.should.equal(@options[:image])
+      end
+
+      it "has the correct target" do
+        @subject.target.should.equal(@target)
+      end
+
+      it "has the correct action" do
+        @subject.action.should.equal(:call)
+      end
+    end
+
+    ###############################################################################################
+
+    describe "given options for a styled item with two images" do
+      before do
+        @options = {
+          :styled    => :bordered,
+          :image     => UIImage.alloc.init,
+          :landscape => UIImage.alloc.init
+        }
+        @target  = -> { true }
+        @subject = BW::UIBarButtonItem.build(@options, &@target)
+      end
+
+      it "has the correct class" do
+        @subject.class.should.equal(UIBarButtonItem)
+      end
+
+      it "has the correct style" do
+        @subject.style.should.equal(UIBarButtonItemStyleBordered)
+      end
+
+      it "has the correct image" do
+        @subject.image.should.equal(@options[:image])
+      end
+
+      it "has the correct iPhone landscape image" do
+        @subject.landscapeImagePhone.should.equal(@options[:landscape])
+      end
+
+      it "has the correct target" do
+        @subject.target.should.equal(@target)
+      end
+
+      it "has the correct action" do
+        @subject.action.should.equal(:call)
+      end
+    end
+
+    ###############################################################################################
+
+    describe "given options for a system item" do
+      before do
+        @options = { :system => :save }
+        @target  = -> { true }
+        @subject = BW::UIBarButtonItem.build(@options, &@target)
+      end
+
+      it "has the correct class" do
+        @subject.class.should.equal(UIBarButtonItem)
+      end
+
+      it "has the correct system item" do
+        @subject.systemItem.should.equal(UIBarButtonSystemItemSave)
+      end
+
+      it "has the correct target" do
+        @subject.target.should.equal(@target)
+      end
+
+      it "has the correct action" do
+        @subject.action.should.equal(:call)
+      end
+    end
+
+    ###############################################################################################
+
+    describe "given options for a custom view" do
+      before do
+        @options = { :custom => UIView.alloc.init }
+        @target  = -> { true }
+        @subject = BW::UIBarButtonItem.build(@options, &@target)
+      end
+
+      it "has the correct class" do
+        @subject.class.should.equal(UIBarButtonItem)
+      end
+
+      it "has a custom view" do
+        @subject.customView.should.equal(@options[:custom])
+      end
+
+      it "adds one, single tap gesture recognizer to the custom view" do
+        @options[:custom].gestureRecognizers.size.should.equal(1)
+        @options[:custom].gestureRecognizers.first.class.should.equal(UITapGestureRecognizer)
+        @options[:custom].gestureRecognizers.first.numberOfTapsRequired.should.equal(1)
+      end
+    end
+
+    ###############################################################################################
+
+    describe "given options for a view" do
+      before do
+        @options = { :view => UIView.alloc.init }
+        @target  = -> { true }
+        @subject = BW::UIBarButtonItem.build(@options, &@target)
+      end
+
+      it "has the correct class" do
+        @subject.class.should.equal(UIBarButtonItem)
+      end
+
+      it "has a custom view" do
+        @subject.customView.should.equal(@options[:view])
+      end
+
+      it "adds one, single tap gesture recognizer to the view" do
+        @options[:view].gestureRecognizers.size.should.equal(1)
+        @options[:view].gestureRecognizers.first.class.should.equal(UITapGestureRecognizer)
+        @options[:view].gestureRecognizers.first.numberOfTapsRequired.should.equal(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Great meeting you at #inspect, @mneorr.

For your consideration, this pull request adds idiomatic Ruby wrappers around the verbose Objective-C `init` methods of UIBarButtonItem.

---
### initWithBarButtonSystemItem:target:action:
#### Before

``` ruby
def cancel_bar_button_item
  UIBarButtonItem.alloc.initWithBarButtonSystemItem(UIBarButtonSystemItemCancel, target:self, action: :cancel)
end

def cancel
  # ...
end
```
#### After

``` ruby
def cancel_bar_button_item
  UIBarButtonItem.system(:cancel) do
    # ...
  end
end
```

---
### initWithTitle:style:target:action:
#### Before

``` ruby
def friends_bar_button_item
  UIBarButtonItem.alloc.initWithTitle("Friends", style:UIBarButtonItemStyleBordered, target:self, action: :friends)
end

def friends
  # ...
end
```
#### After

``` ruby
def friends_bar_button_item
  UIBarButtonItem.styled(:bordered, "Friends") do
    # ...
  end
end
```

---
### initWithImage:style:target:action:
#### Before

``` ruby
def friends_bar_button_item
  image = UIImage.imageNamed("glyph_friends")

  UIBarButtonItem.alloc.initWithImage(image, style:UIBarButtonItemStylePlain, target:self, action: :friends)
end

def friends
  # ...
end
```
#### After

``` ruby
def friends_bar_button_item
  image = UIImage.imageNamed("glyph_friends")

  UIBarButtonItem.styled(:plain, image) do
    # ...
  end
end
```

---
### initWithImage:landscapeImagePhone:style:target:action:
#### Before

``` ruby
def friends_bar_button_item
  image                 = UIImage.imageNamed("glyph_friends")
  image_landscape_phone = UIImage.imageNamed("glyph_friends_landscape_phone")

  UIBarButtonItem.alloc.initWithImage(image, landscapeImagePhone:image_landscape_phone, style:UIBarButtonItemStylePlain, target:self, action: :friends)
end

def friends
  # ...
end
```
#### After

``` ruby
def friends_bar_button_item
  image                 = UIImage.imageNamed("glyph_friends")
  image_landscape_phone = UIImage.imageNamed("glyph_friends_landscape_phone")

  UIBarButtonItem.styled(:plain, [image, image_landscape_phone]) do
    # ...
  end
end
```

**NOTE:** If's more pleasing to your sense of style, I'm open to refactoring the method signature like so:

``` ruby
UIBarButtonItem.styled(:plain, image, image_landscape_phone) do
  # ...
end
```

Personally, I prefer this cleaner syntax.  Just be aware that it'll add some complexity to the method implementation.  Let me know which you prefer.

---
### initWithCustomView:
#### Before

``` ruby
def custom_bar_button_item
  view = MyCustomView.alloc.init

  UIBarButtonItem.alloc.initWithCustomView(view)
end

```
#### After

``` ruby
def custom_bar_button_item
  view = MyCustomView.alloc.init

  UIBarButtonItem.custom(view)
end
```

**NOTE:** I made this wrapper for the sake of completeness and consistency.

---

Questions?  Comments?  Suggestions?
