### PR TITLE
:cookie-option for BubbleWrap::HTTP::Query

### DIFF
--- a/motion/http.rb
+++ b/motion/http.rb
@@ -87,6 +87,7 @@ module BubbleWrap
       # a proc will receive a Response object while the passed object
       # will receive the handle_query_response method
       # :headers<Hash>     - headers send with the request
+      # :cookies<Boolean>  - Set whether cookies should be sent with request or not (Default: true)
       # Anything else will be available via the options attribute reader.
       #
       def initialize(url_string, http_method = :get, options={})
@@ -102,6 +103,7 @@ module BubbleWrap
         @format = options.delete(:format)
         @cache_policy = options.delete(:cache_policy) || NSURLRequestUseProtocolCachePolicy
         @credential_persistence = options.delete(:credential_persistence) || NSURLCredentialPersistenceForSession
+        @cookies = options.key?(:cookies) ? options.delete(:cookies) : true      
         @options = options
         @response = HTTP::Response.new
         @follow_urls = options[:follow_urls] || true
@@ -211,6 +213,7 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
         set_content_type
         request.setAllHTTPHeaderFields(@headers)
         request.setHTTPBody(@body)
+        request.setHTTPShouldHandleCookies(@cookies)
         patch_nsurl_request(request)
 
         request

--- a/spec/motion/http_spec.rb
+++ b/spec/motion/http_spec.rb
@@ -708,6 +708,25 @@ describe "HTTP" do
 
     end
 
+    describe 'properly support cookie-option for nsmutableurlrequest' do 
+      
+      before do 
+        @no_cookie_query = BubbleWrap::HTTP::Query.new("http://fake.url", :get, {:payload => {:something => "else"}, :cookies => false})
+        @cookie_query = BubbleWrap::HTTP::Query.new("http://fake.url", :get, :payload => {:something => "else"})
+      end
+
+      it 'should disabled cookie-usage on nsurlrequest' do 
+        puts @no_cookie_query.instance_variable_get(:@cookies).inspect
+        @no_cookie_query.instance_variable_get(:@request).HTTPShouldHandleCookies.should.equal false
+      end
+
+      it 'should keep sane cookie-related defaults on nsurlrequest' do 
+        @cookie_query.instance_variable_get(:@request).HTTPShouldHandleCookies.should.equal true
+      end
+
+
+    end
+
     class FakeSender
       attr_reader :challenge, :credential, :was_cancelled, :continue_without_credential
       def cancelAuthenticationChallenge(challenge)


### PR DESCRIPTION
I've added the option :cookie to options for BubbleWrap::HTTP::Query in order to support turning HTTPShouldHandleCookies off/on on NSMutableURLRequest.
