### PR TITLE
Everyone needs to know this, so I want to put it in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,8 @@ simple interface:
 # ['NBC', 'ABC', 'Fox', 'CBS', 'PBS']
 > App::Persistence['channels'] = ['TF1', 'France 2', 'France 3']
 # ['TF1', 'France 2', 'France 3']
+> App::Persistence['something__new'] # something previously never stored
+# nil
 ```
 
 ### Observers


### PR DESCRIPTION
It's not explicitly shown what is returned when you first call app persistence.  This is something EVERY app will have on first run, so why not show that it's nil and not error or some other object.
