### PR TITLE
HTTP: updating query and response after authentication failure

### DIFF
--- a/motion/http/query.rb
+++ b/motion/http/query.rb
@@ -70,9 +70,7 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
     if App.osx? && !response.is_a?(NSHTTPURLResponse)
       return
     end
-    @status_code = response.statusCode
-    @response_headers = response.allHeaderFields
-    @response_size = response.expectedContentLength.to_f
+    did_receive_response(response)
   end
 
   # This delegate method get called every time a chunk of data is being received
@@ -139,6 +137,8 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
         log "auth challenged, answered with credentials: #{credentials.inspect}"
       end
     else
+      did_receive_response(challenge.failureResponse)
+      @response.update(status_code: status_code, headers: response_headers, url: @url, original_url: @original_url)
       challenge.sender.cancelAuthenticationChallenge(challenge)
       log 'Auth Failed :('
     end
@@ -147,7 +147,12 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
 
   private
 
-  private
+  def did_receive_response(response)
+    @status_code = response.statusCode
+    @response_headers = response.allHeaderFields
+    @response_size = response.expectedContentLength.to_f
+  end
+
   def show_status_indicator(show)
     if App.ios?
       UIApplication.sharedApplication.networkActivityIndicatorVisible = show

--- a/spec/motion/http/query_spec.rb
+++ b/spec/motion/http/query_spec.rb
@@ -608,10 +608,18 @@ describe BubbleWrap::HTTP::Query do
       @query.connection(nil, didReceiveAuthenticationChallenge:@challenge)
     end
 
-    it "should cancel the authentication if the failure count was not 0" do
-      @challenge.previousFailureCount = 1
-      @query.connection(nil, didReceiveAuthenticationChallenge:@challenge)
-      @challenge.sender.was_cancelled.should.equal true
+    describe "given the failure count was not 0" do
+      before { @challenge.previousFailureCount = 1 }
+
+      it "should cancel the authentication" do
+        @query.connection(nil, didReceiveAuthenticationChallenge:@challenge)
+        @challenge.sender.was_cancelled.should.equal true
+      end
+
+      it "should set the response fields" do
+        @query.connection(nil, didReceiveAuthenticationChallenge:@challenge)
+        @query.response.status_code.should.equal @challenge.failureResponse.statusCode
+      end
     end
 
     it "should pass in Credentials and the challenge itself to the sender" do
@@ -695,10 +703,14 @@ describe BubbleWrap::HTTP::Query do
   end
 
   class FakeChallenge
-    attr_accessor :previousFailureCount
+    attr_accessor :previousFailureCount, :failureResponse
 
     def sender
       @fake_sender ||= FakeSender.new
+    end
+
+    def failureResponse
+      @failureResponse ||= FakeURLResponse.new(401, { bla: "123" }, 123)
     end
   end
 


### PR DESCRIPTION
I noticed that when making a request with wrong credentials both the `Query` object returned and the `Response` object yielded to the block have the `status_code` set to nil. There's actually no easy way of knowing why the request is failing.

Im not 100% sure that this is correct behaviour, but I believe it would be convenient to set the response status to `401` unauthorized request. 

Im very new at ios and rubymotion, so the way Im fixing this might not be the best. Comments and suggestions are more than welcome.

**Implementation note**
Im calling the method `Query#connection:didReceiveResponse` from `Query#connection:didReceiveAuthenticationChallenge` and Im not sure if it's a good practice to do this, since it's a callback method and I dont know if we are supposed to use it. 
