### PR TITLE
BW::HTTP: Proactively present credentials before challenge

### DIFF
--- a/motion/http.rb
+++ b/motion/http.rb
@@ -97,7 +97,7 @@ module BubbleWrap
         @files = options.delete(:files)
         @boundary = options.delete(:boundary) || BW.create_uuid
         @credentials = options.delete(:credentials) || {}
-        @credentials = {:username => '', :password => ''}.merge(@credentials)
+        @credentials = {:username => nil, :password => nil}.merge(@credentials)
         @timeout = options.delete(:timeout) || 30.0
         @headers = escape_line_feeds(options.delete :headers)
         @format = options.delete(:format)
@@ -107,7 +107,7 @@ module BubbleWrap
         @options = options
         @response = HTTP::Response.new
         @follow_urls = options[:follow_urls] || true
-        @present_credentials = options.delete(:present_credentials) || false
+        @present_credentials = options[:present_credentials] == nil ? true : options.delete(:present_credentials)
 
         @url = create_url(url_string)
         @body = create_request_body
@@ -245,6 +245,10 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
         @headers && @headers.keys.find {|k| k.downcase == 'content-type'}
       end
 
+      def credentials_provided?
+        @credentials[:username] && @credentials[:password]
+      end
+
       def create_request_body
         return nil if (@method == "GET" || @method == "HEAD")
         return nil unless (@payload || @files)
@@ -286,7 +290,7 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
       def append_auth_header
         return if @headers && @headers["Authorization"]
 
-        if @credentials != {} && @present_credentials
+        if credentials_provided? && @present_credentials
           mock_request = CFHTTPMessageCreateRequest(nil, nil, nil, nil)
           CFHTTPMessageAddAuthentication(mock_request, nil, @credentials[:username], @credentials[:password], KCFHTTPAuthenticationSchemeBasic, false)
 

--- a/spec/motion/http_spec.rb
+++ b/spec/motion/http_spec.rb
@@ -202,7 +202,7 @@ describe "HTTP" do
         options = { credentials: {} }
         new_query = BubbleWrap::HTTP::Query.new( @localhost_url, :get,  options)
 
-        generated_credentials = {:username => '', :password => ''}
+        generated_credentials = { :username => nil, :password => nil }
         new_query.credentials.should.equal generated_credentials
         options.should.be.empty
       end
@@ -335,8 +335,10 @@ describe "HTTP" do
       end
 
       it "should delete :headers from options and escape Line Feeds" do
-        escaped_lf = {"User-Agent"=>"Mozilla/5.0 (X11; Linux x86_64; rv:12.0) \r\n Gecko/20100101 Firefox/12.0"}
-        @query.instance_variable_get(:@headers).should.equal escaped_lf
+        escaped_lf = "Mozilla/5.0 (X11; Linux x86_64; rv:12.0) \r\n Gecko/20100101 Firefox/12.0"
+        headers = @query.instance_variable_get(:@headers)
+        
+        headers["User-Agent"].should.equal escaped_lf
       end
 
       it "should delete :cache_policy or set NSURLRequestUseProtocolCachePolicy" do
@@ -355,11 +357,17 @@ describe "HTTP" do
         new_query.instance_variable_get(:@credential_persistence).should.equal NSURLCredentialPersistenceForSession
       end
 
-      it "should present credentials when asked to :present_credentials" do
-        query = BubbleWrap::HTTP::Query.new(@fake_url, :get, { credentials: @credentials, present_credentials: true })
-        headers = query.instance_variable_get(:@headers)
+      it "should present base64-encoded credentials in Authorization header when provided" do
+        headers = @query.instance_variable_get(:@headers)
 
         headers["Authorization"].should.equal "Basic bW5lb3JyOjEyMzQ1Nnh4IUBjcmF6eQ=="
+      end
+
+      it "should not present Authorization header when :present_credentials is false" do
+        query = BubbleWrap::HTTP::Query.new(@fake_url, :get, { credentials: @credentials, present_credentials: false })
+        headers = query.instance_variable_get(:@headers)
+
+        headers.should.equal nil
       end
 
       it "should set the rest of options{} to ivar @options" do


### PR DESCRIPTION
I'm developing against an API that uses HTTP Basic authentication, but it seems `BW::HTTP` will only present the given `:credentials` if the server responds with a 401 on the initial request. 

I know the HTTP spec _recommends_ (but not does _mandate_) waiting for a challenge first, but it seems kind of wasteful to send two requests when you know for sure the server requires authentication. I'd be happy to implement a `present_credentials: true` option, or something like that, for BubbleWrap if people agree that should be an option?

As a side note, I found a weird thing I cannot explain. In my specs, `BW::HTTP::Query` doesn't seem to send the second request (with the `Authentication` header) after initially receiving the 401 -- but the exact same code does when running it, for example, in the REPL. In practicality, we plan to mock these requests in our specs, but I thought I would raise it nonetheless because I don't know if this is expected behaviour or not - it seems weird.
