### PR TITLE
Refactor BW::UIBarButtonItem module to a class

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,11 @@ end
 
 ### UIBarButtonItem
 
-`BW::UIBarButtonItem` provides an idiomatic Ruby syntax for instantiating `UIBarButtonItem` objects.  Instead of a target-action pair, each method accepts a block.  When the button is tapped, the block is executed.  As a convenience, the block is optional.
+`BW::UIBarButtonItem` is a subclass of `UIBarButtonItem` with an natural Ruby syntax.
+
+#### Constructors
+
+Instead specifying a target-action pair, each constructor method accepts an optional block.  When the button is tapped, the block is executed.
 
 ```ruby
 BW::UIBarButtonItem.system(:save) do
@@ -443,21 +447,21 @@ end
 # NOTE: The block is attached to the view as a single tap gesture recognizer.
 ```
 
-Alternatively, `BW::UIBarButtonItem` provides a flexible, builder-style syntax for dynamically instantiating `UIBarButtonItem` objects.
+The `.new` constructor provides a flexible, builder-style syntax.
 
 ```ruby
 options = { :system => :save }
-BW::UIBarButtonItem.build(options) do
+BW::UIBarButtonItem.new(options) do
   # ...
 end
 
 options = { :styled => :plain, :title => "Friends" }
-BW::UIBarButtonItem.build(options) do
+BW::UIBarButtonItem.new(options) do
   # ...
 end
 
 options = { :styled => :bordered, :image => UIImage.alloc.init }
-BW::UIBarButtonItem.build(options) do
+BW::UIBarButtonItem.new(options) do
   # ...
 end
 
@@ -466,16 +470,18 @@ options = {
   :image     => UIImage.alloc.init,
   :landscape => UIImage.alloc.init
 }
-BW::UIBarButtonItem.build(options) do
+BW::UIBarButtonItem.new(options) do
   # ...
 end
 
 options = { :custom => UIView.alloc.init }
-BW::UIBarButtonItem.build(options) do
+BW::UIBarButtonItem.new(options) do
   # ...
 end
 # NOTE: The block is attached to the view as a single tap gesture recognizer.
 ```
+
+#### Button types
 
 The `.styled` button types are:
 

--- a/motion/ui/ui_bar_button_item.rb
+++ b/motion/ui/ui_bar_button_item.rb
@@ -1,68 +1,70 @@
 module BW
-  module UIBarButtonItem
-    module_function
+  class UIBarButtonItem < ::UIBarButtonItem
+    class << self
+      def styled(type, *objects, &block)
+        action = block ? :call : nil
+        object = objects.size == 1 ? objects.first : objects
+        style  = Constants.get("UIBarButtonItemStyle", type)
 
-    def styled(type, *objects, &block)
-      action = block ? :call : nil
-      object = objects.size == 1 ? objects.first : objects
-      style  = Constants.get("UIBarButtonItemStyle", type)
+        item = if object.is_a?(String)
+          alloc.initWithTitle(object,
+            style:style,
+            target:block,
+            action:action
+          )
+        elsif object.is_a?(UIImage)
+          alloc.initWithImage(object,
+            style:style,
+            target:block,
+            action:action
+          )
+        elsif object.is_a?(Array) && object.size == 2 && object.all? { |o| o.is_a?(UIImage) }
+          alloc.initWithImage(object[0],
+            landscapeImagePhone:object[1],
+            style:style,
+            target:block,
+            action:action
+          )
+        else
+          raise ArgumentError, "invalid object - #{object.inspect}"
+        end
 
-      item = if object.is_a?(String)
-        ::UIBarButtonItem.alloc.initWithTitle(object,
-          style:style,
-          target:block,
-          action:action
-        )
-      elsif object.is_a?(UIImage)
-        ::UIBarButtonItem.alloc.initWithImage(object,
-          style:style,
-          target:block,
-          action:action
-        )
-      elsif object.is_a?(Array) && object.size == 2 && object.all? { |o| o.is_a?(UIImage) }
-        ::UIBarButtonItem.alloc.initWithImage(object[0],
-          landscapeImagePhone:object[1],
-          style:style,
-          target:block,
-          action:action
-        )
-      else
-        raise ArgumentError, "invalid object - #{object.inspect}"
+        item.instance_variable_set(:@target, block)
+        item
       end
 
-      item.instance_variable_set(:@target, block)
-      item
-    end
+      def system(type, &block)
+        action      = block ? :call : nil
+        system_item = Constants.get("UIBarButtonSystemItem", type)
 
-    def system(type, &block)
-      action      = block ? :call : nil
-      system_item = Constants.get("UIBarButtonSystemItem", type)
-
-      item = ::UIBarButtonItem.alloc.initWithBarButtonSystemItem(system_item,
-        target:block,
-        action:action
-      )
-      item.instance_variable_set(:@target, block)
-      item
-    end
-
-    def custom(view, &block)
-      view.when_tapped(true, &block) if block
-      ::UIBarButtonItem.alloc.initWithCustomView(view)
-    end
-
-    def build(options = {}, &block)
-      if options[:styled]
-        args = options.values_at(:title, :image, :landscape).compact
-        return styled(options[:styled], *args, &block)
+        item = alloc.initWithBarButtonSystemItem(system_item, target:block, action:action)
+        item.instance_variable_set(:@target, block)
+        item
       end
 
-      return system(options[:system], &block) if options[:system]
+      def custom(view, &block)
+        view.when_tapped(true, &block) if block
+        alloc.initWithCustomView(view)
+      end
 
-      return custom(options[:custom], &block) if options[:custom]
-      return custom(options[:view],   &block) if options[:view]
+      def new(options = {}, &block)
+        if options[:styled]
+          args = options.values_at(:title, :image, :landscape).compact
+          return styled(options[:styled], *args, &block)
+        end
 
-      raise ArgumentError, "invalid options - #{options.inspect}"
+        return system(options[:system], &block) if options[:system]
+
+        return custom(options[:custom], &block) if options[:custom]
+        return custom(options[:view],   &block) if options[:view]
+
+        raise ArgumentError, "invalid options - #{options.inspect}"
+      end
+
+      def build(options = {}, &block)
+        NSLog "[DEPRECATED - BW::UIBarButtonItem.build] please use .new instead."
+        new(options, &block)
+      end
     end
   end
 

--- a/spec/motion/ui/ui_bar_button_item_spec.rb
+++ b/spec/motion/ui/ui_bar_button_item_spec.rb
@@ -24,7 +24,11 @@ describe BW::UIBarButtonItem do
       end
 
       it "has the correct class" do
-        @subject.class.should.equal(UIBarButtonItem)
+        @subject.class.should.equal(BW::UIBarButtonItem)
+      end
+
+      it "has the correct superclass" do
+        @subject.superclass.should.equal(::UIBarButtonItem)
       end
 
       it "has the correct style" do
@@ -53,7 +57,11 @@ describe BW::UIBarButtonItem do
       end
 
       it "has the correct class" do
-        @subject.class.should.equal(UIBarButtonItem)
+        @subject.class.should.equal(BW::UIBarButtonItem)
+      end
+
+      it "has the correct superclass" do
+        @subject.superclass.should.equal(::UIBarButtonItem)
       end
 
       it "has the correct style" do
@@ -83,7 +91,11 @@ describe BW::UIBarButtonItem do
       end
 
       it "has the correct class" do
-        @subject.class.should.equal(UIBarButtonItem)
+        @subject.class.should.equal(BW::UIBarButtonItem)
+      end
+
+      it "has the correct superclass" do
+        @subject.superclass.should.equal(::UIBarButtonItem)
       end
 
       it "has the correct style" do
@@ -114,7 +126,11 @@ describe BW::UIBarButtonItem do
       end
 
       it "has the correct class" do
-        @subject.class.should.equal(UIBarButtonItem)
+        @subject.class.should.equal(BW::UIBarButtonItem)
+      end
+
+      it "has the correct superclass" do
+        @subject.superclass.should.equal(::UIBarButtonItem)
       end
 
       it "has the correct style" do
@@ -158,7 +174,11 @@ describe BW::UIBarButtonItem do
       end
 
       it "has the correct class" do
-        @subject.class.should.equal(UIBarButtonItem)
+        @subject.class.should.equal(BW::UIBarButtonItem)
+      end
+
+      it "has the correct superclass" do
+        @subject.superclass.should.equal(::UIBarButtonItem)
       end
 
       it "has the correct system item" do
@@ -183,7 +203,11 @@ describe BW::UIBarButtonItem do
       end
 
       it "has the correct class" do
-        @subject.class.should.equal(UIBarButtonItem)
+        @subject.class.should.equal(BW::UIBarButtonItem)
+      end
+
+      it "has the correct superclass" do
+        @subject.superclass.should.equal(::UIBarButtonItem)
       end
 
       it "has the correct system item" do
@@ -211,7 +235,11 @@ describe BW::UIBarButtonItem do
       end
 
       it "has the correct class" do
-        @subject.class.should.equal(UIBarButtonItem)
+        @subject.class.should.equal(BW::UIBarButtonItem)
+      end
+
+      it "has the correct superclass" do
+        @subject.superclass.should.equal(::UIBarButtonItem)
       end
 
       it "has a custom view" do
@@ -234,7 +262,11 @@ describe BW::UIBarButtonItem do
       end
 
       it "has the correct class" do
-        @subject.class.should.equal(UIBarButtonItem)
+        @subject.class.should.equal(BW::UIBarButtonItem)
+      end
+
+      it "has the correct superclass" do
+        @subject.superclass.should.equal(::UIBarButtonItem)
       end
 
       it "has a custom view" do
@@ -249,17 +281,17 @@ describe BW::UIBarButtonItem do
 
   #################################################################################################
 
-  describe ".build" do
+  describe ".new" do
     describe "not given options" do
       it "raises an exception" do
-        exception = should.raise(ArgumentError) { BW::UIBarButtonItem.build }
+        exception = should.raise(ArgumentError) { BW::UIBarButtonItem.new }
         exception.message.should.equal("invalid options - {}")
       end
     end
 
     describe "given unknown options" do
       it "raises an exception" do
-        exception = should.raise(ArgumentError) { BW::UIBarButtonItem.build(:unknown => true) }
+        exception = should.raise(ArgumentError) { BW::UIBarButtonItem.new(:unknown => true) }
         exception.message.should.equal("invalid options - {:unknown=>true}")
       end
     end
@@ -274,7 +306,7 @@ describe BW::UIBarButtonItem do
       end
 
       it "raises an exception" do
-        exception = should.raise(ArgumentError) { BW::UIBarButtonItem.build(@options) }
+        exception = should.raise(ArgumentError) { BW::UIBarButtonItem.new(@options) }
         exception.message.should.equal("invalid object - #{@options.values_at(:title, :image)}")
       end
     end
@@ -285,11 +317,15 @@ describe BW::UIBarButtonItem do
       before do
         @options = { :styled => :plain, :title => "Friends" }
         @target  = -> { true }
-        @subject = BW::UIBarButtonItem.build(@options, &@target)
+        @subject = BW::UIBarButtonItem.new(@options, &@target)
       end
 
       it "has the correct class" do
-        @subject.class.should.equal(UIBarButtonItem)
+        @subject.class.should.equal(BW::UIBarButtonItem)
+      end
+
+      it "has the correct superclass" do
+        @subject.superclass.should.equal(::UIBarButtonItem)
       end
 
       it "has the correct style" do
@@ -315,11 +351,15 @@ describe BW::UIBarButtonItem do
       before do
         @options = { :styled => :bordered, :image => UIImage.alloc.init }
         @target  = -> { true }
-        @subject = BW::UIBarButtonItem.build(@options, &@target)
+        @subject = BW::UIBarButtonItem.new(@options, &@target)
       end
 
       it "has the correct class" do
-        @subject.class.should.equal(UIBarButtonItem)
+        @subject.class.should.equal(BW::UIBarButtonItem)
+      end
+
+      it "has the correct superclass" do
+        @subject.superclass.should.equal(::UIBarButtonItem)
       end
 
       it "has the correct style" do
@@ -349,11 +389,15 @@ describe BW::UIBarButtonItem do
           :landscape => UIImage.alloc.init
         }
         @target  = -> { true }
-        @subject = BW::UIBarButtonItem.build(@options, &@target)
+        @subject = BW::UIBarButtonItem.new(@options, &@target)
       end
 
       it "has the correct class" do
-        @subject.class.should.equal(UIBarButtonItem)
+        @subject.class.should.equal(BW::UIBarButtonItem)
+      end
+
+      it "has the correct superclass" do
+        @subject.superclass.should.equal(::UIBarButtonItem)
       end
 
       it "has the correct style" do
@@ -383,11 +427,15 @@ describe BW::UIBarButtonItem do
       before do
         @options = { :system => :save }
         @target  = -> { true }
-        @subject = BW::UIBarButtonItem.build(@options, &@target)
+        @subject = BW::UIBarButtonItem.new(@options, &@target)
       end
 
       it "has the correct class" do
-        @subject.class.should.equal(UIBarButtonItem)
+        @subject.class.should.equal(BW::UIBarButtonItem)
+      end
+
+      it "has the correct superclass" do
+        @subject.superclass.should.equal(::UIBarButtonItem)
       end
 
       it "has the correct system item" do
@@ -409,11 +457,15 @@ describe BW::UIBarButtonItem do
       before do
         @options = { :custom => UIView.alloc.init }
         @target  = -> { true }
-        @subject = BW::UIBarButtonItem.build(@options, &@target)
+        @subject = BW::UIBarButtonItem.new(@options, &@target)
       end
 
       it "has the correct class" do
-        @subject.class.should.equal(UIBarButtonItem)
+        @subject.class.should.equal(BW::UIBarButtonItem)
+      end
+
+      it "has the correct superclass" do
+        @subject.superclass.should.equal(::UIBarButtonItem)
       end
 
       it "has a custom view" do
@@ -433,11 +485,15 @@ describe BW::UIBarButtonItem do
       before do
         @options = { :view => UIView.alloc.init }
         @target  = -> { true }
-        @subject = BW::UIBarButtonItem.build(@options, &@target)
+        @subject = BW::UIBarButtonItem.new(@options, &@target)
       end
 
       it "has the correct class" do
-        @subject.class.should.equal(UIBarButtonItem)
+        @subject.class.should.equal(BW::UIBarButtonItem)
+      end
+
+      it "has the correct superclass" do
+        @subject.superclass.should.equal(::UIBarButtonItem)
       end
 
       it "has a custom view" do


### PR DESCRIPTION
So, I've come to a realization.  I think that changing `BW::UIBarButtonItem` to a subclass (rather than a factory module) is a better architecture pattern for BubbleWrap's future.

My original design for `BW::UIBarButtonItem` was a factory module because:
1. I was concerned that overloading `+init` on `UIBarButtonItem` would be dangerous.
2. Someday, I wanted to explore the option of polluting `UIBarButtonItem` itself.
3. I disliked the thought of typing `BubbleWrap::` all the time.

However, I've since changed my mind while implementing `BW::UIAlertView`:
1. lrz reminded me that overloading `.new` on Cocoa Touch classes is quite safe.
2. I've given up on my dream to pollute Cocoa Touch classes because of the potential compatibility issues it creates with other 3rd party libraries.
3. I've actually grown found of seeing `BW::` in my code.  :)

---

This patch has **no behavior changes** and **maintains backward-compatibility**.  The only changes are:
- The constructor methods now return instances of `BW::UIBarButtonItem` which is a subclass of `UIBarButtonItem`.
- The `.new` constructor method replaces `.build`.  Calling `.build` forwards to `.new` and outputs a deprecation warning to `NSLog`.
