### PR TITLE
When timeout occurs, send :timeout arg to errback

### DIFF
--- a/motion/reactor/deferrable.rb
+++ b/motion/reactor/deferrable.rb
@@ -118,7 +118,7 @@ module BubbleWrap
       def timeout(seconds)
         cancel_timeout
         me = self
-        @deferred_timeout = Timer.new(seconds) {me.fail}
+        @deferred_timeout = Timer.new(seconds) {me.fail(:timeout)}
       end
 
     end


### PR DESCRIPTION
Need to know the reason for the fail.

Having trouble writing a spec for this, timeouts are not triggering while sleeping, could use some help.
