### PR TITLE
Reactor::Eventable doesn't fire all registered procs of an event when a proc unregisters itself

### DIFF
--- a/motion/reactor/eventable.rb
+++ b/motion/reactor/eventable.rb
@@ -19,8 +19,9 @@ module BubbleWrap
 
       # Trigger an event
       def trigger(event, *args)
-        __events__[event].map do |event|
-          event.call(*args)
+        blks = __events__[event].clone
+        blks.map do |blk|
+          blk.call(*args)
         end
       end
 

--- a/spec/motion/reactor/eventable_spec.rb
+++ b/spec/motion/reactor/eventable_spec.rb
@@ -30,6 +30,21 @@ describe BubbleWrap::Reactor::Eventable do
       @subject.off(:foo, &proof)
       events[:foo].member?(proof).should == false
     end
+
+    it 'calls other event procs when a proc unregisters itself' do
+      @proxy.proof = 0
+      proof1 = proc do |r|
+        @proxy.proof += r
+        @subject.off(:foo, &proof1)
+      end
+      proof2 = proc do |r|
+        @proxy.proof += r
+      end
+      @subject.on(:foo, &proof1)
+      @subject.on(:foo, &proof2)
+      @subject.trigger(:foo, 2)
+      @proxy.proof.should == 4
+    end
   end
 
   describe '.trigger' do


### PR DESCRIPTION
``` ruby
proc1 = proc do
  puts 'proc 1'
  off(:foo, &proc1)
end
proc2 = proc do
  puts 'proc 2'
end
on(:foo, &proc1)
on(:foo, &proc2)
trigger(:foo)
```

`proc2`is never called:

``` ruby
=> "proc 1"
```
