### PR TITLE
Document iOS4 alternative/disclaimer with BW::JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ end
 
 ### JSON
 
-`BW::JSON` wraps `NSJSONSerialization` available in iOS5 and offers the same API as Ruby's JSON std lib.
+`BW::JSON` wraps `NSJSONSerialization` available in iOS5 and offers the same API as Ruby's JSON std lib. For apps building for iOS4, we suggest a different JSON alternative, like [AnyJSON](https://github.com/mattt/AnyJSON).
 
 ```ruby
 BW::JSON.generate({'foo => 1, 'bar' => [1,2,3], 'baz => 'awesome'})


### PR DESCRIPTION
Closes #178 with documentation on `BW::JSON` and iOS4. Offers an alternative to `BW::JSON` by suggesting [AnyJSON](https://github.com/mattt/AnyJSON).
