### PR TITLE
Added info_plist method to App

### DIFF
--- a/motion/core/app.rb
+++ b/motion/core/app.rb
@@ -43,8 +43,12 @@ module BubbleWrap
       @states
     end
 
+    def info_plist
+      NSBundle.mainBundle.infoDictionary
+    end
+
     def name
-      NSBundle.mainBundle.objectForInfoDictionaryKey 'CFBundleDisplayName'
+      info_plist['CFBundleDisplayName']
     end
 
     def identifier
@@ -52,7 +56,7 @@ module BubbleWrap
     end
 
     def version
-      NSBundle.mainBundle.infoDictionary['CFBundleVersion']
+      info_plist['CFBundleVersion']
     end
 
     # @return [NSLocale] locale of user settings
@@ -90,5 +94,6 @@ module BubbleWrap
       Kernel.const_defined?(:UIApplication)
     end
   end
+
 end
 ::App = BubbleWrap::App unless defined?(::App)

--- a/spec/motion/core/app_spec.rb
+++ b/spec/motion/core/app_spec.rb
@@ -36,6 +36,12 @@ describe BubbleWrap::App do
     end
   end
 
+  describe '.info_plist' do
+    it 'returns the information property list hash' do
+      App.info_plist.should == NSBundle.mainBundle.infoDictionary
+    end
+  end
+
   describe '.name' do
     it 'returns the application name' do
       App.name.should == 'testSuite'


### PR DESCRIPTION
Added utility method to `App` to be able to access the Information Property List hash. Closes #267.
