### PR TITLE
add a workaround for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
 before_install:
     - (ruby --version)
+before_script: sudo chown -R travis ~/Library/RubyMotion
 script: ./travis.sh


### PR DESCRIPTION
Now, there is a permission error in travis.
    "Cannot write into the `/Users/travis/Library/RubyMotion/build' directory, please remove or check permissions and try again."
    https://travis-ci.org/rubymotion/BubbleWrap/builds/9522953

This way is provided by ProMotion gem
https://github.com/clearsightstudio/ProMotion/commit/40e51fc2713735f7db5bca8a6b837a3466afca2c
