### PR TITLE
fix the spec result where invalid TAP format result would be generated

### DIFF
--- a/spec/motion/http/query_spec.rb
+++ b/spec/motion/http/query_spec.rb
@@ -209,7 +209,6 @@ describe BubbleWrap::HTTP::Query do
         payload = { name: 'apple', model: 'macbook'}
         files = { twitter: sample_data, site: "mneorr.com".dataUsingEncoding(NSUTF8StringEncoding) }
 
-        puts "\n"
         [:post, :put, :delete, :patch].each do |method|
           puts "    - #{method}\n"
           query = BubbleWrap::HTTP::Query.new( @fake_url , method, { payload: payload, files: files } )
@@ -233,7 +232,6 @@ describe BubbleWrap::HTTP::Query do
 
       it "sets the payload as a string if JSON" do
         json = "{\"foo\":42,\"bar\":\"BubbleWrap\"}"
-        puts "\n"
         [:put, :post, :delete, :patch].each do |method|
           puts "    - #{method}\n"
           query = BubbleWrap::HTTP::Query.new( @fake_url , method, { payload: json } )


### PR DESCRIPTION
The TAP result is not displayed on the way if it use Jenkins TAP plugin.

The displaying of result stops at No.209 spec.
![result](https://dl.dropboxusercontent.com/s/u2r74y10v3vj16r/BubbleWrap_tap_result.png?token_hash=AAFXEXJjpD75DrW0FIA_i1iJnncwNMnkvQH0sGZABQaseQ&dl=1)
