### PR TITLE
Update readme: notification_center methods take a string, not a class

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Helper methods to give NSNotificationCenter a Ruby-like interface:
 
 ```ruby
 def viewWillAppear(animated)
-  @foreground_observer = App.notification_center.observe 'UIApplicationWillEnterForegroundNotification' do |notification|
+  @foreground_observer = App.notification_center.observe UIApplicationWillEnterForegroundNotification do |notification|
     loadAndRefresh
   end
 


### PR DESCRIPTION
These methods call addObserverForName and postNotificationName, passing in the parameter as the name in both cases, so the readme should reflect that.

See https://github.com/rubymotion/BubbleWrap/blob/master/motion/core/ns_notification_center.rb
