### PR TITLE
moved string module inclusion from String to NSString.

### DIFF
--- a/motion/core/string.rb
+++ b/motion/core/string.rb
@@ -71,4 +71,4 @@ module BubbleWrap
   end
 end
 
-String.send(:include, BubbleWrap::String)
+NSString.send(:include, BubbleWrap::String)

--- a/spec/motion/core/string_spec.rb
+++ b/spec/motion/core/string_spec.rb
@@ -1,8 +1,8 @@
 describe BubbleWrap::String do
 
-  describe ::String do
+  describe ::NSString do
     it 'should include BubbleWrap::String' do
-      ::String.ancestors.member?(BubbleWrap::String).should == true
+      ::NSString.ancestors.member?(BubbleWrap::String).should == true
     end
   end
 


### PR DESCRIPTION
So far, BubbleWrap::String was not applied to NSString.
This causes problems when working with methods which returns NSString like JSON.parse.

ex)
hash = BW::JSON.parse('{"color": "#002244"}')
str = hash['to_color']  # str is NSString not String
str.to_color      # raises undefined method error because str is NSString

str.class returns String, but actually not.

now it works because BubbleWrap::String is included into NSString.
