### PR TITLE
Change `map` to `map!` to save extra array creation and use Interpolation

### DIFF
--- a/motion/core/persistence.rb
+++ b/motion/core/persistence.rb
@@ -41,7 +41,7 @@ module BubbleWrap
     end
 
     def storage_key(key)
-      app_key + '_' + key.to_s
+      "#{app_key}_#{key}"
     end
   end
 

--- a/motion/core/string.rb
+++ b/motion/core/string.rb
@@ -55,9 +55,9 @@ module BubbleWrap
       hex_color = self.gsub("#", "")   
       case hex_color.size 
         when 3
-          colors = hex_color.scan(%r{[0-9A-Fa-f]}).map{ |el| (el * 2).to_i(16) }
+          colors = hex_color.scan(%r{[0-9A-Fa-f]}).map!{ |el| (el * 2).to_i(16) }
         when 6
-          colors = hex_color.scan(%r<[0-9A-Fa-f]{2}>).map{ |el| el.to_i(16) }        
+          colors = hex_color.scan(%r<[0-9A-Fa-f]{2}>).map!{ |el| el.to_i(16) }
         else
           raise ArgumentError
       end 


### PR DESCRIPTION
Minor changes:
- Change `map` to `map!` to save extra array creation 
- Use faster String interpolation instead of concat
