### PR TITLE
Fix App#window to work with iOS7 style action sheets

### DIFF
--- a/motion/core/ios/app.rb
+++ b/motion/core/ios/app.rb
@@ -63,9 +63,21 @@ module BubbleWrap
       UIApplication.sharedApplication
     end
 
+    def windows
+      UIApplication.sharedApplication.windows
+    end
+
     # the Application Window
     def window
-      UIApplication.sharedApplication.keyWindow || UIApplication.sharedApplication.windows[0]
+      normal_windows = App.windows.select { |w|
+        w.windowLevel == UIWindowLevelNormal
+      }
+
+      key_window = normal_windows.select {|w|
+        w == UIApplication.sharedApplication.keyWindow
+      }.first
+
+      key_window || normal_windows.first
     end
   end
 end

--- a/spec/motion/core/ios/app_spec.rb
+++ b/spec/motion/core/ios/app_spec.rb
@@ -3,6 +3,9 @@ describe BubbleWrap::App do
     describe '.alert' do
       after do
         @alert.dismissWithClickedButtonIndex(@alert.cancelButtonIndex, animated: false)
+
+        wait 0.3 do
+        end
       end
 
       describe "with only one string argument" do
@@ -138,9 +141,35 @@ describe BubbleWrap::App do
       end
     end
 
+    describe '.windows' do
+      it 'returns UIApplication.sharedApplication.windows' do
+        App.windows.should == UIApplication.sharedApplication.windows
+      end
+    end
+
     describe '.window' do
       it 'returns UIApplication.sharedApplication.keyWindow' do
         App.window.should == UIApplication.sharedApplication.keyWindow
+      end
+
+      describe 'with UIActionSheet' do
+
+        it 'returns the correct window' do
+          action_sheet = UIActionSheet.alloc.init
+          action_sheet.cancelButtonIndex = (action_sheet.addButtonWithTitle("Cancel"))
+
+          old_window = App.window
+          window_count = App.windows.count
+          action_sheet.showInView(App.window)
+          wait 1 do
+            UIApplication.sharedApplication.windows.count.should > window_count
+            App.window.should == old_window
+
+            action_sheet.dismissWithClickedButtonIndex(action_sheet.cancelButtonIndex, animated: false)
+
+            App.window.should == old_window
+          end
+        end
       end
     end
 


### PR DESCRIPTION
`App.window` should return the application-level most likely used by the app. iOS7 has introduced implementation changes to how modal views work, which complicates the `UIWindow` hierarchy.

@matthewsinclair what do you think about this? basically `App.window` should return the expected window, thus the expected `rootViewController`. Folks shouldn't have to do a bunch of checks every time, like #304. will merge when you take a look
