### PR TITLE
Make sure Location callback exists before calling it

### DIFF
--- a/motion/location/location.rb
+++ b/motion/location/location.rb
@@ -112,11 +112,11 @@ module BubbleWrap
     # CLLocationManagerDelegate Methods
     def locationManager(manager, didUpdateToLocation:newLocation, fromLocation:oldLocation)
       if @options[:once]
-        @callback.call(newLocation)
+        @callback && @callback.call(newLocation)
         @callback = proc { |result| }
         stop
       else
-        @callback.call({to: newLocation, from: oldLocation})
+        @callback && @callback.call({to: newLocation, from: oldLocation})
       end
     end
 


### PR DESCRIPTION
I sometimes get this error:
**Terminating app due to uncaught exception 'NoMethodError', reason: 'undefined method call' for nil:NilClass (NoMethodError)**
at `locationManager:didUpdateToLocation:fromLocation: (location.rb:119)`

This PR just makes sure @callback exists before calling it, just like it's already done in the error handler.
