### PR TITLE
Make HTTP connections run in all common run loop modes

### DIFF
--- a/motion/http/query.rb
+++ b/motion/http/query.rb
@@ -53,6 +53,7 @@ module BubbleWrap; module HTTP; class Query
     @original_url = @url.copy
 
     @connection = create_connection(request, self)
+    @connection.scheduleInRunLoop(NSRunLoop.currentRunLoop, forMode:NSRunLoopCommonModes)
     @connection.start
 
     show_status_indicator true
@@ -381,7 +382,7 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
 
   # This is a temporary method used for mocking.
   def create_connection(request, delegate)
-    NSURLConnection.connectionWithRequest(request, delegate:delegate)
+    NSURLConnection.alloc.initWithRequest(request, delegate:delegate, startImmediately:false)
   end
 
 end; end; end


### PR DESCRIPTION
HTTP requests currently don't run on all run loop modes, e.g. if you're scrolling in a view. The consequence is that nothing loads until you release your finger from the screen. Very problematic in an image feed.

This PR make them run on all common run loop modes.

More info: http://stackoverflow.com/a/10134198/2726506
This fix has been extensively tested in production in my app [Frontback](http://frontback.me) for two months and works perfectly.
