### PR TITLE
Removed UIKit from requirements. Fixes #312

### DIFF
--- a/lib/bubble-wrap/requirement.rb
+++ b/lib/bubble-wrap/requirement.rb
@@ -85,7 +85,7 @@ module BubbleWrap
       end
 
       def frameworks(app_frameworks=nil)
-        frameworks = ['UIKit', 'Foundation', 'CoreGraphics'] +
+        frameworks = ['Foundation', 'CoreGraphics'] +
           paths.values.map(&:frameworks)
         frameworks += app_frameworks if app_frameworks
         frameworks.flatten.compact.sort.uniq


### PR DESCRIPTION
Not sure of any other implications that this might have on iOS apps, but RM includes UIKit by default so we shouldn't really even need that in the array.
