### PR TITLE
Modify KVO#observe with target = self as default

### DIFF
--- a/motion/core/kvo.rb
+++ b/motion/core/kvo.rb
@@ -21,12 +21,26 @@ module BubbleWrap
     COLLECTION_OPERATIONS = [ NSKeyValueChangeInsertion, NSKeyValueChangeRemoval, NSKeyValueChangeReplacement ]
     DEFAULT_OPTIONS = NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
 
-    def observe(target, key_path, &block)
+    def observe(*arguments, &block)
+      unless [1,2].include?(arguments.length)
+        raise ArgumentError, "wrong number of arguments (#{arguments.length} for 1 or 2)"
+      end
+
+      key_path = arguments.pop
+      target   = arguments.pop || self
+
       target.addObserver(self, forKeyPath:key_path, options:DEFAULT_OPTIONS, context:nil) unless registered?(target, key_path)
       add_observer_block(target, key_path, &block)
     end
 
-    def unobserve(target, key_path)
+    def unobserve(*arguments)
+      unless [1,2].include?(arguments.length)
+        raise ArgumentError, "wrong number of arguments (#{arguments.length} for 1 or 2)"
+      end
+
+      key_path = arguments.pop
+      target   = arguments.pop || self
+
       return unless registered?(target, key_path)
 
       target.removeObserver(self, forKeyPath:key_path)

--- a/spec/motion/core/kvo_spec.rb
+++ b/spec/motion/core/kvo_spec.rb
@@ -3,11 +3,13 @@ describe BubbleWrap::KVO do
   class KvoExample
     include BubbleWrap::KVO
 
+    attr_accessor :age
     attr_accessor :label
     attr_accessor :items
 
     def initialize
       @items = [ "Apple", "Banana", "Chickpeas" ]
+      @age = 1
 
       if App.osx?
         @label = NSTextField.alloc.initWithFrame [[0,0],[320, 30]]
@@ -185,6 +187,31 @@ describe BubbleWrap::KVO do
       @example.unobserve_label
     
       @example.set_text "Bar"
+      observed.should == false
+    end
+
+    # without target
+
+    it "should observe a key path without a target" do
+      observed = false
+      @example.observe :age do |old_value, new_value|
+        observed = true
+        old_value.should == 1
+        new_value.should == 2
+      end
+    
+      @example.age = 2
+      observed.should == true
+    end
+
+    it "should unobserve a key path without a target" do
+      observed = false
+      @example.observe :age do |old_value, new_value|
+        observed = true
+      end
+      @example.unobserve :age
+    
+      @example.age = 2
       observed.should == false
     end
   


### PR DESCRIPTION
As explained in #311 this allows the KVO API to be called without a target object which is then set to self by default:

``` ruby
@example.observe :key, &block
# is the same as
@example.observe @example, :key, &block
```
