### PR TITLE
Update presentation of mail controller to include completion block

### DIFF
--- a/motion/mail/mail.rb
+++ b/motion/mail/mail.rb
@@ -30,7 +30,7 @@ module BubbleWrap
       @mail_controller = create_mail_controller(options)
       
       @mailer_is_animated = options[:animated] == false ? false : true
-      @delegate.presentModalViewController(@mail_controller, animated: @mailer_is_animated)
+      @delegate.presentViewController(@mail_controller, animated: @mailer_is_animated, completion: options[:completion])
     end
     
     def create_mail_controller(options={})

--- a/spec/motion/mail/mail_spec.rb
+++ b/spec/motion/mail/mail_spec.rb
@@ -2,7 +2,7 @@
 class MailViewController < UIViewController
   attr_accessor :expectation
   
-  def presentModalViewController(modal, animated: animated)
+  def presentViewController(modal, animated: animated, completion: completion)
     expectation.call modal, animated
   end
 end


### PR DESCRIPTION
Since the Mail Controller popover isn't a real view and can cause issues with the status bar coloring (http://stackoverflow.com/questions/18945390/mfmailcomposeviewcontroller-in-ios-7-statusbar-are-black) the solution seems to be to use a completion block on the mail presenter method.

However the current implementation uses the deprecated `presentModalViewController`, this pull request updates that to `presentViewController` and adds support for a `completion` option being passed.
