### PR TITLE
Making the bubble-wrap motion project initializer to call the original setup function

### DIFF
--- a/lib/bubble-wrap/ext/motion_project_app.rb
+++ b/lib/bubble-wrap/ext/motion_project_app.rb
@@ -4,7 +4,7 @@ module BubbleWrap
 
       def self.extended(base)
         base.instance_eval do
-          def setup_with_bubblewrap(&block)
+          def setup_with_bubblewrap(*args, &block)
             bw_config = proc do |app|
               app.files = ::BubbleWrap::Requirement.files(app.files)
               app.files_dependencies ::BubbleWrap::Requirement.files_dependencies
@@ -12,6 +12,8 @@ module BubbleWrap
               block.call(app) unless block.nil?
             end
             config.setup_blocks << bw_config
+
+            setup_without_bubblewrap *args, &block
           end
           alias :setup_without_bubblewrap :setup
           alias :setup :setup_with_bubblewrap


### PR DESCRIPTION
hey guys, i think i've got a quick fix for the bubble wrap's initialization.

basically the problem is that i've got another rubymotion extension, which also taps into the `setup` function and as bubble-wrap never calls the original setup after it initializes itself, the other extensions don't get configured.
