### PR TITLE
Allow for fractional seconds in iso8601 time parsing

### DIFF
--- a/motion/core/time.rb
+++ b/motion/core/time.rb
@@ -9,6 +9,11 @@ class Time
     cached_date_formatter("yyyy-MM-dd'T'HH:mm:ssZZZZZ").
       dateFromString(time)
   end
+  
+  def self.iso8601_with_fractional_seconds(time)
+    cached_date_formatter("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").
+      dateFromString(time)
+  end
 
   private
 

--- a/spec/motion/core/time_spec.rb
+++ b/spec/motion/core/time_spec.rb
@@ -18,11 +18,13 @@ describe "Time" do
     before do
       @time = Time.iso8601("2012-#{Time.now.month}-#{Time.now.day}T19:41:32Z")
       @time_with_timezone = Time.iso8601_with_timezone("1987-08-10T06:00:00+02:00")
+      @time_with_fractional_seconds = Time.iso8601_with_fractional_seconds("2012-#{Time.now.month}-#{Time.now.day}T19:41:32.123Z")
     end
 
     it "should be a time" do
       @time.instance_of?(Time).should == true
       @time_with_timezone.instance_of?(Time).should == true
+      @time_with_fractional_seconds.instance_of?(Time).should == true
     end
 
     # Crashes Buggy RubyMotion 1.18
@@ -30,36 +32,43 @@ describe "Time" do
       local_zone = Time.now.zone
       @time.zone.should == local_zone
       @time_with_timezone.zone == local_zone
+      @time_with_fractional_seconds.zone.should == local_zone
     end
 
     it "should have a valid year" do
       @time.utc.year.should == 2012
       @time_with_timezone.utc.year.should == 1987
+      @time_with_fractional_seconds.utc.year.should == 2012
     end
 
     it "should have a valid month" do
       @time.utc.month.should == Time.now.month
       @time_with_timezone.utc.month.should == 8
+      @time_with_fractional_seconds.utc.month.should == Time.now.month
     end
 
     it "should have a valid day" do
       @time.utc.day.should == Time.now.day
       @time_with_timezone.utc.day.should == 10
+      @time_with_fractional_seconds.utc.day.should == Time.now.day
     end
 
     it "should have a valid hour" do
       @time.utc.hour.should == 19
       @time_with_timezone.utc.hour.should == 4
+      @time_with_fractional_seconds.utc.hour.should == 19
     end
 
     it "should have a valid minute" do
       @time.utc.min.should == 41
       @time_with_timezone.utc.min.should == 0
+      @time_with_fractional_seconds.utc.min.should == 41
     end
 
     it "should have a valid second" do
       @time.utc.sec.should == 32
       @time_with_timezone.utc.sec.should == 0
+      @time_with_fractional_seconds.utc.sec.should == 32
     end
   end
 


### PR DESCRIPTION
Because jbuilder in Rails outputs it. In console it looks like this:

```
> Time.current.iso8601
> "2014-01-17T23:07:08Z"
```

But in jbuilder, this:

```
json.extract! @object, :id, :created_at
```

Outputs:

```
{"id":"d1f0b6f4-9156-402f-9758-51c09055c296","created_at":"2014-01-17T04:08:15.739Z"}
```

Note the fractional seconds, it's actually legit according to ISO8601. But that doesn't help to quell my sadness. So I added a new method and updated the specs:

Time.now.iso8601_with_fractional_seconds

I didn't modify the original because it is also legit.

Other people have run into this...
http://stackoverflow.com/questions/17449298/rails-jbuilder-datetime-adding-decimals-to-second
