### PR TITLE
Added method to check if device has a physical camera.

### DIFF
--- a/motion/core/device/ios/camera.rb
+++ b/motion/core/device/ios/camera.rb
@@ -34,7 +34,7 @@ module BubbleWrap
         @rear ||= Camera.new(:rear)
       end
 
-      def self.physical_camera?
+      def self.available?
         UIImagePickerController.isSourceTypeAvailable(UIImagePickerControllerSourceTypeCamera)
       end
 

--- a/motion/core/device/ios/camera_wrapper.rb
+++ b/motion/core/device/ios/camera_wrapper.rb
@@ -47,8 +47,8 @@ module BubbleWrap
 
       # Verifies that the device running has a physical camera.
       # @return [TrueClass, FalseClass] true will be returned if the device has a physical camera, false otherwise.
-      def physical_camera?
-        BubbleWrap::Device::Camera.physical_camera?
+      def available?
+        BubbleWrap::Device::Camera.available?
       end
     end
   end

--- a/spec/motion/core/device/ios/camera_wrapper_spec.rb
+++ b/spec/motion/core/device/ios/camera_wrapper_spec.rb
@@ -29,9 +29,9 @@ describe BubbleWrap::Device::CameraWrapper do
       end
     end
 
-    describe '.physical_camera?' do
+    describe '.available?' do
       it 'returns true' do
-        BW::Device.camera.physical_camera?.should == true
+        BW::Device.camera.available?.should == true
       end
     end
   end
@@ -60,9 +60,9 @@ describe BubbleWrap::Device::CameraWrapper do
       end
     end
 
-    describe '.physical_camera?' do
+    describe '.available?' do
       it 'returns true' do
-        BW::Device.camera.physical_camera?.should == true
+        BW::Device.camera.available?.should == true
       end
     end
   end
@@ -91,9 +91,9 @@ describe BubbleWrap::Device::CameraWrapper do
       end
     end
 
-    describe '.physical_camera?' do
+    describe '.available?' do
       it 'returns true' do
-        BW::Device.camera.physical_camera?.should == false
+        BW::Device.camera.available?.should == false
       end
     end
   end


### PR DESCRIPTION
I was missing a method to check if there was a physical camera available (front or rear). This commit adds a method physical_camera? to the camera wrapper.

Device.camera.any? returns always true because it returns the photo library, which was kind of confusing for me. 
