### PR TITLE
Do not show warnings about iOS when building for OSX

### DIFF
--- a/lib/bubble-wrap/core.rb
+++ b/lib/bubble-wrap/core.rb
@@ -9,12 +9,12 @@ BubbleWrap.require('motion/core/device/*.rb')
 BubbleWrap.require_ios do
   BubbleWrap.require('motion/core/ios/**/*.rb')
   BubbleWrap.require('motion/core/device/ios/**/*.rb')
+  
+  require 'bubble-wrap/camera'
+  require 'bubble-wrap/ui'
 end
 
 BubbleWrap.require_osx do
   BubbleWrap.require('motion/core/osx/**/*.rb')
   BubbleWrap.require('motion/core/device/osx/**/*.rb')
 end
-
-require 'bubble-wrap/camera'
-require 'bubble-wrap/ui'


### PR DESCRIPTION
This will suppress annoying warnings

```
bubble-wrap/camera requires iOS to use.
bubble-wrap/ui requires iOS to use.

```

when building on OSX. 
