### PR TITLE
Add when_screen_edge_panned for UIScreenEdgePanGestureRecognizer

### DIFF
--- a/motion/ui/ui_view_wrapper.rb
+++ b/motion/ui/ui_view_wrapper.rb
@@ -20,6 +20,10 @@ module BubbleWrap
       add_gesture_recognizer_helper(UIPanGestureRecognizer.alloc.initWithTarget(self, action:'handle_gesture:'), enableInteraction, proc)
     end
 
+    def when_screen_edge_panned(enableInteraction=true, &proc)
+      add_gesture_recognizer_helper(UIScreenEdgePanGestureRecognizer.alloc.initWithTarget(self, action:'handle_gesture:'), enableInteraction, proc)
+    end
+
     def when_pressed(enableInteraction=true, &proc)
       add_gesture_recognizer_helper(UILongPressGestureRecognizer.alloc.initWithTarget(self, action:'handle_gesture:'), enableInteraction, proc)
     end

--- a/spec/motion/ui/ui_view_wrapper_spec.rb
+++ b/spec/motion/ui/ui_view_wrapper_spec.rb
@@ -54,6 +54,10 @@ describe BW::UIViewWrapper do
       testMethod.call :whenPanned
     end
 
+    describe '#when_screen_edge_panned' do
+      testMethod.call :when_screen_edge_panned
+    end
+
     describe '#when_pressed' do
       testMethod.call :when_pressed
       testMethod.call :whenPressed


### PR DESCRIPTION
`UIScreenEdgePanGestureRecognizer` is an iOS7 and newer recognizer for detecting a pan at defined edges of the screen.

I didn't add a `if Device.ios_version < "7.0"` assuming that a proper `uninitialized constant UIScreenEdgePanGestureRecognizer` would be raised in the case that it's called in a pre-iOS7 environment. Let me know if such a check is necessary, but I do not have any way to test behavior in iOS6 and older.
