### PR TITLE
Allows user to set the allowsCellularAccess

### DIFF
--- a/motion/http/query.rb
+++ b/motion/http/query.rb
@@ -43,6 +43,7 @@ module BubbleWrap; module HTTP; class Query
     @timeout = options.delete(:timeout) || 30.0
     @headers = escape_line_feeds(options.delete :headers)
     @format = options.delete(:format)
+    @allows_cellular_access = options.has_key?(:allows_cellular_access) ? options.delete(:allows_cellular_access) : true
     @cache_policy = options.delete(:cache_policy) || NSURLRequestUseProtocolCachePolicy
     @credential_persistence = options.delete(:credential_persistence) || NSURLCredentialPersistenceForSession
     @cookies = options.key?(:cookies) ? options.delete(:cookies) : true
@@ -200,6 +201,7 @@ Cache policy: #{@cache_policy}, response: #{@response.inspect} >"
     set_content_type
     append_auth_header
     request.setAllHTTPHeaderFields(@headers)
+    request.setAllowsCellularAccess(@allows_cellular_access)
     request.setHTTPBody(@body)
     request.setHTTPShouldHandleCookies(@cookies)
     patch_nsurl_request(request)


### PR DESCRIPTION
This patch allows disable cellular access per request. eg, use WIFI only.

It sets whether the connection can use the device’s cellular radio (if present). default: true.

```
BW::HTTP.get('http://example.com', {allows_cellular_access: false}) do |response|
    ...
end
```

background of this option can be found [here](https://developer.apple.com/library/ios/documentation/NetworkingInternetWeb/Conceptual/NetworkingOverview/Platform-SpecificNetworkingTechnologies/Platform-SpecificNetworkingTechnologies.html#//apple_ref/doc/uid/TP40010220-CH212-SW9)
