### PR TITLE
Remove instantiating Device as BW::Device

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Make sure to append onto the array or use `+=`.
 ```ruby
 class AppDelegate
   def application(application, didFinishLaunchingWithOptions:launchOptions)
-    puts "#{App.name} (#{App.documents_path})"
+    puts "#{BW::App.name} (#{BW::App.documents_path})"
     true
   end
 end
@@ -169,43 +169,43 @@ BubbleWrap.debug?
 A module with useful methods related to the running application
 
 ```ruby
-> App.documents_path
+> BW::App.documents_path
 # "/Users/mattetti/Library/Application Support/iPhone Simulator/5.0/Applications/EEC6454E-1816-451E-BB9A-EE18222E1A8F/Documents"
-> App.resources_path
+> BW::App.resources_path
 # "/Users/mattetti/Library/Application Support/iPhone Simulator/5.0/Applications/EEC6454E-1816-451E-BB9A-EE18222E1A8F/testSuite_spec.app"
-> App.name
+> BW::App.name
 # "testSuite"
-> App.identifier
+> BW::App.identifier
 # "io.bubblewrap.testSuite"
-> App.alert("BubbleWrap is awesome!")
+> BW::App.alert("BubbleWrap is awesome!")
 # creates and shows an alert message.
-> App.alert("BubbleWrap is awesome!", {cancel_button_title: "I know it is!", message: "Like, seriously awesome."})
+> BW::App.alert("BubbleWrap is awesome!", {cancel_button_title: "I know it is!", message: "Like, seriously awesome."})
 # creates and shows an alert message with optional parameters.
-> App.run_after(0.5) {  p "It's #{Time.now}"   }
+> BW::App.run_after(0.5) {  p "It's #{Time.now}"   }
 # Runs the block after 0.5 seconds.
-> App.open_url("http://matt.aimonetti.net")
+> BW::App.open_url("http://matt.aimonetti.net")
 # Opens the url using the device's browser. (accepts a string url or an instance of `NSURL`.
-> App::Persistence['channels'] # application specific persistence storage
+> BW::App::Persistence['channels'] # application specific persistence storage
 # ['NBC', 'ABC', 'Fox', 'CBS', 'PBS']
-> App::Persistence['channels'] = ['TF1', 'France 2', 'France 3']
+> BW::App::Persistence['channels'] = ['TF1', 'France 2', 'France 3']
 # ['TF1', 'France 2', 'France 3']
-> App.environment
+> BW::App.environment
 # 'test'
 ```
 
 Other available methods:
 
-* `App.notification_center`
-* `App.user_cache`
-* `App.states`
-* `App.frame`
-* `App.delegate`
-* `App.shared`
-* `App.window`
-* `App.current_locale`
-* `App.release?`
-* `App.test?`
-* `App.development?`
+* `BW::App.notification_center`
+* `BW::App.user_cache`
+* `BW::App.states`
+* `BW::App.frame`
+* `BW::App.delegate`
+* `BW::App.shared`
+* `BW::App.window`
+* `BW::App.current_locale`
+* `BW::App.release?`
+* `BW::App.test?`
+* `BW::App.development?`
 
 
 ### Device
@@ -215,31 +215,31 @@ A collection of useful methods about the current device:
 Examples:
 
 ```ruby
-> Device.iphone?
+> BW::Device.iphone?
 # true
-> Device.ipad?
+> BW::Device.ipad?
 # false
-> Device.camera.front?
+> BW::Device.camera.front?
 # true
-> Device.camera.rear?
+> BW::Device.camera.rear?
 # true
-> Device.orientation
+> BW::Device.orientation
 # :portrait
-> Device.interface_orientation
+> BW::Device.interface_orientation
 # :portrait
-> Device.simulator?
+> BW::Device.simulator?
 # true
-> Device.ios_version
+> BW::Device.ios_version
 # "6.0"
-> Device.retina?
+> BW::Device.retina?
 # false
-> Device.screen.width
+> BW::Device.screen.width
 # 320
-> Device.screen.height
+> BW::Device.screen.height
 # 480
-> Device.screen.width_for_orientation(:landscape_left)
+> BW::Device.screen.width_for_orientation(:landscape_left)
 # 480
-> Device.screen.height_for_orientation(:landscape_left)
+> BW::Device.screen.height_for_orientation(:landscape_left)
 # 320
 ```
 
@@ -287,22 +287,22 @@ Helper methods to give NSNotificationCenter a Ruby-like interface:
 
 ```ruby
 def viewWillAppear(animated)
-  @foreground_observer = App.notification_center.observe UIApplicationWillEnterForegroundNotification do |notification|
+  @foreground_observer = BW::App.notification_center.observe UIApplicationWillEnterForegroundNotification do |notification|
     loadAndRefresh
   end
 
-  @reload_observer = App.notification_center.observe 'ReloadNotification' do |notification|
+  @reload_observer = BW::App.notification_center.observe 'ReloadNotification' do |notification|
     loadAndRefresh
   end
 end
 
 def viewWillDisappear(animated)
-  App.notification_center.unobserve @foreground_observer
-  App.notification_center.unobserve @reload_observer
+  BW::App.notification_center.unobserve @foreground_observer
+  BW::App.notification_center.unobserve @reload_observer
 end
 
 def reload
-  App.notification_center.post 'ReloadNotification'
+  BW::App.notification_center.post 'ReloadNotification'
 end
 ```
 
@@ -310,7 +310,7 @@ end
 ### NSUserDefaults
 
 Helper methods added to the class repsonsible for user preferences used
-by the `App::Persistence` module shown below.
+by the `BW::App::Persistence` module shown below.
 
 ### Persistence
 
@@ -318,13 +318,13 @@ Offers a way to persist application specific information using a very
 simple interface:
 
 ``` ruby
-> App::Persistence['channels'] # application specific persistence storage
+> BW::App::Persistence['channels'] # application specific persistence storage
 # ['NBC', 'ABC', 'Fox', 'CBS', 'PBS']
-> App::Persistence['channels'] = ['TF1', 'France 2', 'France 3']
+> BW::App::Persistence['channels'] = ['TF1', 'France 2', 'France 3']
 # ['TF1', 'France 2', 'France 3']
-> App::Persistence.delete('channels')
+> BW::App::Persistence.delete('channels')
 # ['TF1', 'France 2', 'France 3']
-> App::Persistence['something__new'] # something previously never stored
+> BW::App::Persistence['something__new'] # something previously never stored
 # nil
 ```
 
@@ -713,9 +713,9 @@ BW::HTTP.post("http://foo.bar.com/", {payload: data}) do |response|
     json = BW::JSON.parse(response.body.to_str)
     p json['id']
   elsif response.status_code.to_s =~ /40\d/
-    App.alert("Login failed")
+    BW::App.alert("Login failed")
   else
-    App.alert(response.error_message)
+    BW::App.alert(response.error_message)
   end
 end
 ```
@@ -765,7 +765,7 @@ class HttpClient
     BW::HTTP.get(user_url(user_id)) do |response|
       # ..
     end
-  end 
+  end
 end
 ```
 

--- a/motion/core/app.rb
+++ b/motion/core/app.rb
@@ -99,4 +99,3 @@ module BubbleWrap
   end
 
 end
-::App = BubbleWrap::App unless defined?(::App)

--- a/motion/core/device.rb
+++ b/motion/core/device.rb
@@ -13,4 +13,3 @@ module BubbleWrap
     end
   end
 end
-::Device = BubbleWrap::Device unless defined?(::Device)

--- a/spec/motion/core/app_spec.rb
+++ b/spec/motion/core/app_spec.rb
@@ -1,62 +1,62 @@
 describe BubbleWrap::App do
   describe '.documents_path' do
     it 'should end in "/Documents"' do
-      App.documents_path[-10..-1].should == '/Documents'
+      BubbleWrap::App.documents_path[-10..-1].should == '/Documents'
     end
   end
 
   describe '.resources_path' do
     it 'should end in "/testSuite.app"' do
-      if App.osx?
-        App.resources_path.should =~ /\/testSuite(_spec)?.app\/Contents\/Resources$/
+      if BubbleWrap::App.osx?
+        BubbleWrap::App.resources_path.should =~ /\/testSuite(_spec)?.app\/Contents\/Resources$/
       else
-        App.resources_path.should =~ /\/testSuite(_spec)?.app$/
+        BubbleWrap::App.resources_path.should =~ /\/testSuite(_spec)?.app$/
       end
     end
   end
 
   describe '.notification_center' do
     it 'should be a NSNotificationCenter' do
-      App.notification_center.should == NSNotificationCenter.defaultCenter
+      BubbleWrap::App.notification_center.should == NSNotificationCenter.defaultCenter
     end
   end
 
   describe '.user_cache' do
     it 'should be a NSUserDefaults' do
-      App.user_cache.should == NSUserDefaults.standardUserDefaults
+      BubbleWrap::App.user_cache.should == NSUserDefaults.standardUserDefaults
     end
   end
 
   describe '.states' do
     it 'returns a hash' do
-      App.states.class.should == Hash
+      BubbleWrap::App.states.class.should == Hash
     end
     it "returns the real instance variable" do
-      App.states.should == App.instance_variable_get(:@states)
+      BubbleWrap::App.states.should == BubbleWrap::App.instance_variable_get(:@states)
     end
   end
 
   describe '.info_plist' do
     it 'returns the information property list hash' do
-      App.info_plist.should == NSBundle.mainBundle.infoDictionary
+      BubbleWrap::App.info_plist.should == NSBundle.mainBundle.infoDictionary
     end
   end
 
   describe '.name' do
     it 'returns the application name' do
-      App.name.should == 'testSuite'
+      BubbleWrap::App.name.should == 'testSuite'
     end
   end
 
   describe '.identifier' do
     it 'returns the application identifier' do
-      App.identifier.should == 'io.bubblewrap.testSuite_spec'
+      BubbleWrap::App.identifier.should == 'io.bubblewrap.testSuite_spec'
     end
   end
 
   describe '.version' do
     it 'returns the application version' do
-      App.version.should == '1.2.3'
+      BubbleWrap::App.version.should == '1.2.3'
     end
   end
 
@@ -66,7 +66,7 @@ describe BubbleWrap::App do
     it 'should run a block after the provided delay' do
       @test_obj = DelayedRunAfterTest.new
 
-      App.run_after(0.1){ @test_obj.test_value = true }
+      BubbleWrap::App.run_after(0.1){ @test_obj.test_value = true }
       wait_for_change(@test_obj, 'test_value') do
         @test_obj.test_value.should == true
       end
@@ -77,7 +77,7 @@ describe BubbleWrap::App do
   describe ".environment" do
 
     it 'returns current application environment' do
-      App.environment.should.equal "test"
+      BubbleWrap::App.environment.should.equal "test"
     end
 
   end
@@ -85,15 +85,15 @@ describe BubbleWrap::App do
   describe ".test? .release? .development?" do
 
     it 'tests if current application environment is test' do
-      App.test?.should.equal true
+      BubbleWrap::App.test?.should.equal true
     end
 
     it 'tests if current application environment is release' do
-      App.release?.should.equal false
+      BubbleWrap::App.release?.should.equal false
     end
 
     it 'tests if current application environment is development' do
-      App.development?.should.equal false
+      BubbleWrap::App.development?.should.equal false
     end
 
   end

--- a/spec/motion/core/ios/app_spec.rb
+++ b/spec/motion/core/ios/app_spec.rb
@@ -10,7 +10,7 @@ describe BubbleWrap::App do
 
       describe "with only one string argument" do
         before do
-          @alert = App.alert('1.21 Gigawatts!')
+          @alert = BubbleWrap::App.alert('1.21 Gigawatts!')
         end
 
         it 'returns an alert' do
@@ -34,7 +34,7 @@ describe BubbleWrap::App do
 
       describe "with only two string arguments" do
         before do
-          @alert = App.alert('1.21 Gigawatts!', 'Great Scott!')
+          @alert = BubbleWrap::App.alert('1.21 Gigawatts!', 'Great Scott!')
         end
 
         it 'returns an alert' do
@@ -58,7 +58,7 @@ describe BubbleWrap::App do
 
       describe "with variable args" do
         before do
-          @alert = App.alert('1.21 Gigawatts!', cancel_button_title: 'Great Scott!',
+          @alert = BubbleWrap::App.alert('1.21 Gigawatts!', cancel_button_title: 'Great Scott!',
                                                     message: 'Some random message')
         end
 
@@ -87,7 +87,7 @@ describe BubbleWrap::App do
 
       describe "with a block" do
         before do
-          @alert = App.alert('1.21 Gigawatts!') do |alert|
+          @alert = BubbleWrap::App.alert('1.21 Gigawatts!') do |alert|
             alert.message = 'My message!!'
           end
         end
@@ -118,38 +118,38 @@ describe BubbleWrap::App do
 
     describe '.frame' do
       it 'returns Application Frame' do
-        App.frame.should == UIScreen.mainScreen.applicationFrame
+        BubbleWrap::App.frame.should == UIScreen.mainScreen.applicationFrame
       end
     end
 
     describe '.bounds' do
       it 'returns Main Screen bounds' do
-        App.bounds.should == UIScreen.mainScreen.bounds
+        BubbleWrap::App.bounds.should == UIScreen.mainScreen.bounds
       end
     end
 
 
     describe '.delegate' do
       it 'returns a TestSuiteDelegate' do
-        App.delegate.should == UIApplication.sharedApplication.delegate
+        BubbleWrap::App.delegate.should == UIApplication.sharedApplication.delegate
       end
     end
 
     describe '.shared' do
       it 'returns UIApplication.sharedApplication' do
-        App.shared.should == UIApplication.sharedApplication
+        BubbleWrap::App.shared.should == UIApplication.sharedApplication
       end
     end
 
     describe '.windows' do
       it 'returns UIApplication.sharedApplication.windows' do
-        App.windows.should == UIApplication.sharedApplication.windows
+        BubbleWrap::App.windows.should == UIApplication.sharedApplication.windows
       end
     end
 
     describe '.window' do
       it 'returns UIApplication.sharedApplication.keyWindow' do
-        App.window.should == UIApplication.sharedApplication.keyWindow
+        BubbleWrap::App.window.should == UIApplication.sharedApplication.keyWindow
       end
 
       describe 'with UIActionSheet' do
@@ -158,16 +158,16 @@ describe BubbleWrap::App do
           action_sheet = UIActionSheet.alloc.init
           action_sheet.cancelButtonIndex = (action_sheet.addButtonWithTitle("Cancel"))
 
-          old_window = App.window
-          window_count = App.windows.count
-          action_sheet.showInView(App.window)
+          old_window = BubbleWrap::App.window
+          window_count = BubbleWrap::App.windows.count
+          action_sheet.showInView(BubbleWrap::App.window)
           wait 1 do
             UIApplication.sharedApplication.windows.count.should > window_count
-            App.window.should == old_window
+            BubbleWrap::App.window.should == old_window
 
             action_sheet.dismissWithClickedButtonIndex(action_sheet.cancelButtonIndex, animated: false)
 
-            App.window.should == old_window
+            BubbleWrap::App.window.should == old_window
           end
         end
       end
@@ -179,7 +179,7 @@ describe BubbleWrap::App do
       it 'should run a block after the provided delay' do
         @test_obj = DelayedRunAfterTest.new
 
-        App.run_after(0.1){ @test_obj.test_value = true }
+        BubbleWrap::App.run_after(0.1){ @test_obj.test_value = true }
         wait_for_change(@test_obj, 'test_value') do
           @test_obj.test_value.should == true
         end
@@ -195,11 +195,11 @@ describe BubbleWrap::App do
         def application.openURL(url); @url = url end
 
         url = NSURL.URLWithString('http://localhost')
-        App.open_url(url)
+        BubbleWrap::App.open_url(url)
         application.url.should.equal url
 
         url = 'http://localhost'
-        App.open_url(url)
+        BubbleWrap::App.open_url(url)
         application.url.class.should.equal NSURL
         application.url.description.should.equal url
       end

--- a/spec/motion/core/kvo_spec.rb
+++ b/spec/motion/core/kvo_spec.rb
@@ -11,7 +11,7 @@ describe BubbleWrap::KVO do
       @items = [ "Apple", "Banana", "Chickpeas" ]
       @age = 1
 
-      if App.osx?
+      if BubbleWrap::App.osx?
         @label = NSTextField.alloc.initWithFrame [[0,0],[320, 30]]
         @label.stringValue = "Foo"
       else
@@ -23,16 +23,16 @@ describe BubbleWrap::KVO do
     # Test helper
 
     def get_text
-      App.osx? ? @label.stringValue : @label.text
+      BubbleWrap::App.osx? ? @label.stringValue : @label.text
     end
 
     def set_text(text)
-      method = App.osx? ? :stringValue : :text
+      method = BubbleWrap::App.osx? ? :stringValue : :text
       @label.send("#{method}=", text)
     end
 
     def observe_label(&block)
-      method = App.osx? ? :stringValue : :text
+      method = BubbleWrap::App.osx? ? :stringValue : :text
       observe(@label, method, &block)
     end
 
@@ -41,7 +41,7 @@ describe BubbleWrap::KVO do
     end
 
     def unobserve_label
-      method = App.osx? ? :stringValue : :text
+      method = BubbleWrap::App.osx? ? :stringValue : :text
       unobserve(@label, method)
     end
 
@@ -100,7 +100,7 @@ describe BubbleWrap::KVO do
       @example.send(:remove_observer_block, nil, "key_path")
       @example.send(:registered?, target, "key_path").should == true
     end
-  
+
     it "should not remove an observer block if the key path is not present" do
       target = Object.new
       block = lambda { |old_value, new_value| }
@@ -108,7 +108,7 @@ describe BubbleWrap::KVO do
       @example.send(:remove_observer_block, target, nil)
       @example.send(:registered?, target, "key_path").should == true
     end
-  
+
     it "should remove only one observer block" do
       target = Object.new
       block = lambda { |old_value, new_value| }
@@ -118,9 +118,9 @@ describe BubbleWrap::KVO do
       @example.send(:registered?, target, "key_path1").should == false
       @example.send(:registered?, target, "key_path2").should == true
     end
-  
+
     # remove all
-  
+
     it "should remove all observer blocks" do
       target = Object.new
       block = lambda { |old_value, new_value| }
@@ -128,21 +128,21 @@ describe BubbleWrap::KVO do
       @example.send(:add_observer_block, target, "key_path2", &block)
       @example.send(:remove_all_observer_blocks)
       @example.send(:registered?, target, "key_path1").should == false
-      @example.send(:registered?, target, "key_path2").should == false    
+      @example.send(:registered?, target, "key_path2").should == false
     end
-    
+
   end
-  
+
   describe "API" do
     before do
       @example = KvoExample.new
     end
-  
+
     after do
       @example.unobserve_all
       @example = nil
     end
-    
+
     # observe
 
     it "should observe a key path" do
@@ -152,11 +152,11 @@ describe BubbleWrap::KVO do
         old_value.should == "Foo"
         new_value.should == "Bar"
       end
-    
+
       @example.set_text "Bar"
       observed.should == true
     end
-  
+
     it "should observe a key path with more than one block" do
       observed_one = false
       observed_two = false
@@ -170,22 +170,22 @@ describe BubbleWrap::KVO do
       @example.observe_label do |old_value, new_value|
         observed_three = true
       end
-    
+
       @example.set_text "Bar"
       observed_one.should == true
       observed_two.should == true
       observed_three.should == true
     end
-    
+
     # unobserve
-    
+
     it "should unobserve a key path" do
       observed = false
       @example.observe_label do |old_value, new_value|
         observed = true
       end
       @example.unobserve_label
-    
+
       @example.set_text "Bar"
       observed.should == false
     end
@@ -199,7 +199,7 @@ describe BubbleWrap::KVO do
         old_value.should == 1
         new_value.should == 2
       end
-    
+
       @example.age = 2
       observed.should == true
     end
@@ -210,13 +210,13 @@ describe BubbleWrap::KVO do
         observed = true
       end
       @example.unobserve :age
-    
+
       @example.age = 2
       observed.should == false
     end
-  
+
   end
- 
+
 =begin
   it "should be able to observe a collection" do
     observed = false
@@ -224,9 +224,9 @@ describe BubbleWrap::KVO do
       puts "#{collection} #{old_value} #{new_value} #{indexes}"
       observed = true
     end
-    
+
     @example.items << "Dragonfruit"
-    observed.should == true  
+    observed.should == true
   end
 =end
 

--- a/spec/motion/core/ns_index_path_spec.rb
+++ b/spec/motion/core/ns_index_path_spec.rb
@@ -1,7 +1,7 @@
 describe "NSIndexPathWrap" do
 
   before do
-    if App.osx?
+    if BubbleWrap::App.osx?
       @index = NSIndexPath.indexPathWithIndex(3)
     else
       @index = NSIndexPath.indexPathForRow(0, inSection:3)
@@ -17,7 +17,7 @@ describe "NSIndexPathWrap" do
     @index.each do |idx|
       i << idx
     end
-    if App.osx?
+    if BubbleWrap::App.osx?
       i.should == [3]
     else
       i.should == [3, 0]

--- a/spec/motion/core/osx/app_spec.rb
+++ b/spec/motion/core/osx/app_spec.rb
@@ -2,13 +2,13 @@ describe BubbleWrap::App do
   describe "OS X" do
     describe '.delegate' do
       it 'returns a TestSuiteDelegate' do
-        App.delegate.should == NSApplication.sharedApplication.delegate
+        BubbleWrap::App.delegate.should == NSApplication.sharedApplication.delegate
       end
     end
 
     describe '.shared' do
       it 'returns UIApplication.sharedApplication' do
-        App.shared.should == NSApplication.sharedApplication
+        BubbleWrap::App.shared.should == NSApplication.sharedApplication
       end
     end
   end

--- a/spec/motion/core/string_spec.rb
+++ b/spec/motion/core/string_spec.rb
@@ -40,7 +40,7 @@ describe BubbleWrap::String do
 
   describe 'camelCase input' do
     describe '.camelize(true)' do
-      it "upper cases the first character" do 
+      it "upper cases the first character" do
         'camelCase'.camelize(true).should == 'CamelCase'
       end
     end
@@ -92,9 +92,9 @@ describe BubbleWrap::String do
   end
 
   before do
-    @blue_color = App.osx? ? NSColor.colorWithDeviceRed(0,green:0,blue:1,alpha:1) : UIColor.blueColor
+    @blue_color = BubbleWrap::App.osx? ? NSColor.colorWithDeviceRed(0,green:0,blue:1,alpha:1) : UIColor.blueColor
     r,g,b,a = [1, (138.0/255.0), (25.0/255.0), 1]
-    @orange_color = App.osx? ? NSColor.colorWithDeviceRed(r, green:g, blue:b, alpha: a) :
+    @orange_color = BubbleWrap::App.osx? ? NSColor.colorWithDeviceRed(r, green:g, blue:b, alpha: a) :
                                 UIColor.colorWithRed(r, green:g, blue:b, alpha:a)
   end
 
@@ -102,27 +102,27 @@ describe BubbleWrap::String do
 
     it "with 6 digits" do
       @orange_color_from_hex= '#FF8A19'.to_color
-      @orange_color_from_hex.should == @orange_color    
-    end 
+      @orange_color_from_hex.should == @orange_color
+    end
 
-    it "with 3 digits" do 
+    it "with 3 digits" do
       @blue_color_from_hex = '#00F'.to_color
-      @blue_color_from_hex.should ==  @blue_color   
-    end 
+      @blue_color_from_hex.should ==  @blue_color
+    end
 
-    it "with no # sign" do  
+    it "with no # sign" do
       @orange_color_from_hex= 'FF8A19'.to_color
-      @orange_color_from_hex.should == @orange_color    
-    end 
-  end 
+      @orange_color_from_hex.should == @orange_color
+    end
+  end
 
   describe "a string with a color keyword (blue, red, lightText)" do
     it "should return the corresponding color" do
-      'blue'.to_color.should == (App.osx? ? NSColor.blueColor : UIColor.blueColor)
+      'blue'.to_color.should == (BubbleWrap::App.osx? ? NSColor.blueColor : UIColor.blueColor)
     end
 
     it "should accept camelCase" do
-      if App.osx?
+      if BubbleWrap::App.osx?
         'headerText'.to_color.should == NSColor.headerTextColor
       else
         'lightText'.to_color.should == UIColor.lightTextColor
@@ -130,7 +130,7 @@ describe BubbleWrap::String do
     end
 
     it "should accept snake_case" do
-      'dark_gray'.to_color.should == (App.osx? ? NSColor.darkGrayColor : UIColor.darkGrayColor)
+      'dark_gray'.to_color.should == (BubbleWrap::App.osx? ? NSColor.darkGrayColor : UIColor.darkGrayColor)
     end
   end
 
@@ -139,16 +139,16 @@ describe BubbleWrap::String do
     it "an invalid hex color" do
       should.raise( ArgumentError ) {
         'XXX'.to_color
-      }     
+      }
     end
-    
+
     it "a hex color with the wrong number of digits" do
       should.raise( ArgumentError ) {
         'FFFF'.to_color
-      }     
+      }
     end
-    
-  end 
+
+  end
 
   describe "encoding" do
 
@@ -169,7 +169,7 @@ describe BubbleWrap::String do
     it "to_url_decoded" do
       encoded_string = "hey%20ho%20let's%20%7Bgo%7D"
       real_decoded = encoded_string.stringByReplacingPercentEscapesUsingEncoding NSUTF8StringEncoding
-      
+
       encoded_string.to_url_decoded.should.equal real_decoded
     end
 
@@ -180,7 +180,7 @@ describe BubbleWrap::String do
         utf8 = @raw_string.dataUsingEncoding NSUTF8StringEncoding
         @raw_string.to_encoded_data.should.equal utf8
       end
-      
+
       it "handles multiple encodings" do
         utf16 = @raw_string.dataUsingEncoding NSUTF16StringEncoding
         @raw_string.to_encoded_data(NSUTF16StringEncoding).should.equal utf16

--- a/spec/motion/core_spec.rb
+++ b/spec/motion/core_spec.rb
@@ -29,7 +29,7 @@ describe 'BubbleWrap' do
 
     it "creates color with rgb devided by 255 with alpha=1" do
       r,g,b,a = [(@red/255.0), (@green/255.0), (@blue/255.0), 1]
-      if App.osx?
+      if BubbleWrap::App.osx?
         color = NSColor.colorWithDeviceRed(r, green:g, blue:b, alpha: a)
       else
         color = UIColor.colorWithRed(r, green:g, blue:b, alpha:a)
@@ -40,7 +40,7 @@ describe 'BubbleWrap' do
     it "rgba_color uses the real alpha" do
       alpha = 0.4
       r,g,b,a = [(@red/255.0), (@green/255.0), (@blue/255.0), alpha]
-      if App.osx?
+      if BubbleWrap::App.osx?
         color = NSColor.colorWithDeviceRed(r, green:g, blue:b, alpha: a)
       else
         color = UIColor.colorWithRed(r, green:g, blue:b, alpha:a)
@@ -51,7 +51,7 @@ describe 'BubbleWrap' do
   end
 
   describe "Localized string" do
-    
+
     it "loads the string from NSBundle" do
       key = 'real_key'
       value = 'Real Key'
@@ -66,11 +66,11 @@ describe 'BubbleWrap' do
     end
 
   end
-  
+
   describe "uuid" do
 
     it "creates always the new UUID" do
-      previous = BW.create_uuid  
+      previous = BW.create_uuid
       10.times do
         uuid = BW.create_uuid
         uuid.should.not.equal previous

--- a/spec/motion/http/query_spec.rb
+++ b/spec/motion/http/query_spec.rb
@@ -367,7 +367,7 @@ describe BubbleWrap::HTTP::Query do
       @query.connection.was_started.should.equal true
     end
 
-    if App.ios?
+    if BubbleWrap::App.ios?
       it "should turn on the network indicator" do
         UIApplication.sharedApplication.isNetworkActivityIndicatorVisible.should.equal true
       end
@@ -544,7 +544,7 @@ describe BubbleWrap::HTTP::Query do
       @fake_error = NSError.errorWithDomain('testing', code:7768, userInfo:nil)
     end
 
-    if App.ios?
+    if BubbleWrap::App.ios?
       it "should turn off network indicator" do
         UIApplication.sharedApplication.isNetworkActivityIndicatorVisible.should == true
         @query.connection(nil, didFailWithError:@fake_error)
@@ -588,7 +588,7 @@ describe BubbleWrap::HTTP::Query do
 
   describe "when connectionDidFinishLoading:" do
 
-    if App.ios?
+    if BubbleWrap::App.ios?
       it "should turn off the network indicator" do
         @query.connectionDidFinishLoading(nil)
         wait BW::NetworkIndicator::DELAY do
@@ -746,7 +746,7 @@ describe BubbleWrap::HTTP::Query do
       @doa_query.connection.was_cancelled.should.equal true
     end
 
-    if App.ios?
+    if BubbleWrap::App.ios?
       it "should turn off the network indicator" do
         wait BW::NetworkIndicator::DELAY do
           UIApplication.sharedApplication.isNetworkActivityIndicatorVisible.should.equal false
@@ -815,7 +815,7 @@ describe BubbleWrap::HTTP::Query do
   end
 
   after do
-    if App.ios?
+    if BubbleWrap::App.ios?
       sleep(BW::NetworkIndicator::DELAY) if BW::NetworkIndicator.counter > 0
       raise "I think you forgot to 'cancel' a query (in order for BW::NetworkIndicator to be tested properly, all queries must be canceled)" if BW::NetworkIndicator.counter > 0
     end

--- a/spec/motion/media/player_spec.rb
+++ b/spec/motion/media/player_spec.rb
@@ -2,7 +2,7 @@ describe BubbleWrap::Media::Player do
   describe ".play" do
     before do
       @player = BW::Media::Player.new
-      @local_file = NSURL.fileURLWithPath(File.join(App.resources_path, 'test.mp3'))
+      @local_file = NSURL.fileURLWithPath(File.join(BW::App.resources_path, 'test.mp3'))
     end
 
     it "should raise error if not modal and no callback given" do
@@ -33,11 +33,11 @@ describe BubbleWrap::Media::Player do
   describe ".play_modal" do
     before do
       @player = BW::Media::Player.new
-      @local_file = NSURL.fileURLWithPath(File.join(App.resources_path, 'test.mp3'))
+      @local_file = NSURL.fileURLWithPath(File.join(BW::App.resources_path, 'test.mp3'))
     end
 
     it "should present a modalViewController on root if no controller given" do
-      @controller = App.window.rootViewController
+      @controller = BW::App.window.rootViewController
 
       @player.play_modal(@local_file)
 
@@ -61,7 +61,7 @@ describe BubbleWrap::Media::Player do
     end
 
     it "should present a modalViewController if controller given" do
-      parent = App.window.rootViewController
+      parent = BW::App.window.rootViewController
       @controller = UINavigationController.alloc.init
       parent.addChildViewController @controller
       @controller.viewWillAppear(false)

--- a/spec/motion/rss_parser_spec.rb
+++ b/spec/motion/rss_parser_spec.rb
@@ -3,7 +3,7 @@ describe "RSSParser" do
   before do
     @feed_url = 'https://raw.github.com/gist/2952427/9f1522cbe5d77a72c7c96c4fdb4b77bd58d7681e/atom.xml'
     @ns_url = NSURL.alloc.initWithString(@feed_url)
-    @local_feed = File.join(App.resources_path, 'atom.xml')
+    @local_feed = File.join(BW::App.resources_path, 'atom.xml')
   end
 
   describe "initialization" do
@@ -53,7 +53,7 @@ describe "RSSParser" do
           alias_method :original_get, :get
           def get(url, options={}, &block)
             if url == 'https://raw.github.com/gist/2952427/9f1522cbe5d77a72c7c96c4fdb4b77bd58d7681e/atom.xml'
-              string = File.read(File.join(App.resources_path, 'atom.xml'))
+              string = File.read(File.join(BW::App.resources_path, 'atom.xml'))
               yield BW::HTTP::Response.new(body: string.to_data, status_code: 200)
             elsif url == 'http://doesnotexist.com'
               yield BW::HTTP::Response.new(status_code: nil)

--- a/spec/motion/ui/ui_activity_view_controller_wrapper_spec.rb
+++ b/spec/motion/ui/ui_activity_view_controller_wrapper_spec.rb
@@ -14,8 +14,8 @@ describe BubbleWrap::UIActivityViewController do
   end
 
   after do
-    presenting_controller ||= App.window.rootViewController.presentedViewController
-    presenting_controller ||= App.window.rootViewController
+    presenting_controller ||= BW::App.window.rootViewController.presentedViewController
+    presenting_controller ||= BW::App.window.rootViewController
     presenting_controller.dismissViewControllerAnimated(false, completion:nil)
   end
 

--- a/spec/motion/ui/ui_bar_button_item_spec.rb
+++ b/spec/motion/ui/ui_bar_button_item_spec.rb
@@ -20,7 +20,7 @@ describe BW::UIBarButtonItem do
     end
 
     def dealloc
-      App.notification_center.post('NavigationItemContainingBarButtonItem dealloc', nil, {'tag'=>tag})
+      BW::App.notification_center.post('NavigationItemContainingBarButtonItem dealloc', nil, {'tag'=>tag})
       super
     end
   end
@@ -184,7 +184,7 @@ describe BW::UIBarButtonItem do
 
     describe "with BubbleWrap.use_weak_callbacks=true" do
       it "removes cyclic references" do
-        observer = App.notification_center.observe('NavigationItemContainingBarButtonItem dealloc') do |obj|
+        observer = BW::App.notification_center.observe('NavigationItemContainingBarButtonItem dealloc') do |obj|
           if obj.userInfo['tag'] == 1
             @weak_deallocated = true
           elsif obj.userInfo['tag'] == 2
@@ -199,7 +199,7 @@ describe BW::UIBarButtonItem do
           v2 = NavigationItemContainingBarButtonItem.alloc.init_with_styled
           v2.tag = 2
         }
-        App.notification_center.unobserve(observer)
+        BW::App.notification_center.unobserve(observer)
         @weak_deallocated.should.equal true
         @strong_deallocated.should.equal nil
       end
@@ -278,7 +278,7 @@ describe BW::UIBarButtonItem do
 
     describe "with BubbleWrap.use_weak_callbacks=true" do
       it "removes cyclic references" do
-        observer = App.notification_center.observe('NavigationItemContainingBarButtonItem dealloc') do |obj|
+        observer = BW::App.notification_center.observe('NavigationItemContainingBarButtonItem dealloc') do |obj|
           if obj.userInfo['tag'] == 1
             @weak_deallocated = true
           elsif obj.userInfo['tag'] == 2
@@ -293,7 +293,7 @@ describe BW::UIBarButtonItem do
           v2 = NavigationItemContainingBarButtonItem.alloc.init_with_system
           v2.tag = 2
         }
-        App.notification_center.unobserve(observer)
+        BW::App.notification_center.unobserve(observer)
         @weak_deallocated.should.equal true
         @strong_deallocated.should.equal nil
       end

--- a/spec/motion/ui/ui_control_wrapper_spec.rb
+++ b/spec/motion/ui/ui_control_wrapper_spec.rb
@@ -36,12 +36,12 @@ describe BW::UIControlWrapper do
         end
 
         def dealloc
-          App.notification_center.post('ControlSuperView dealloc', nil, {'tag'=>tag})
+          BubbleWrap::App.notification_center.post('ControlSuperView dealloc', nil, {'tag'=>tag})
           super
         end
       end
 
-      observer = App.notification_center.observe('ControlSuperView dealloc') do |obj|
+      observer = BubbleWrap::App.notification_center.observe('ControlSuperView dealloc') do |obj|
         if obj.userInfo['tag'] == 1
           @weak_deallocated = true
         elsif obj.userInfo['tag'] == 2
@@ -56,7 +56,7 @@ describe BW::UIControlWrapper do
         v2 = ControlSuperView.new
         v2.tag = 2
       }
-      App.notification_center.unobserve(observer)
+      BubbleWrap::App.notification_center.unobserve(observer)
       @weak_deallocated.should.equal true
       @strong_deallocated.should.equal nil
     end

--- a/spec/motion/ui/ui_view_controller_wrapper_spec.rb
+++ b/spec/motion/ui/ui_view_controller_wrapper_spec.rb
@@ -6,8 +6,8 @@ describe BW::UIViewControllerWrapper do
       end
 
       it "has the correct content frame" do
-        height   = App.frame.size.height
-        expected = CGRectMake(0, 0, App.frame.size.width, height)
+        height   = BW::App.frame.size.height
+        expected = CGRectMake(0, 0, BW::App.frame.size.width, height)
 
         @subject.content_frame.should.equal(expected)
       end
@@ -23,9 +23,9 @@ describe BW::UIViewControllerWrapper do
       end
 
       it "has the correct content frame" do
-        height   = App.frame.size.height
+        height   = BW::App.frame.size.height
         height   -= @subject.navigationController.navigationBar.frame.size.height
-        expected = CGRectMake(0, 0, App.frame.size.width, height)
+        expected = CGRectMake(0, 0, BW::App.frame.size.width, height)
 
         @subject.content_frame.should.equal(expected)
       end

--- a/spec/motion/ui/ui_view_wrapper_spec.rb
+++ b/spec/motion/ui/ui_view_wrapper_spec.rb
@@ -1,7 +1,7 @@
 describe BW::UIViewWrapper do
   describe "gestures" do
     before do
-      @view = App.delegate.window.rootViewController.view
+      @view = BW::App.delegate.window.rootViewController.view
       @orig = @view.isUserInteractionEnabled
       @view.setUserInteractionEnabled false
     end
@@ -76,12 +76,12 @@ describe BW::UIViewWrapper do
         end
 
         def dealloc
-          App.notification_center.post('ViewSuperView dealloc', nil, {'tag'=>tag})
+          BW::App.notification_center.post('ViewSuperView dealloc', nil, {'tag'=>tag})
           super
         end
       end
 
-      observer = App.notification_center.observe('ViewSuperView dealloc') do |obj|
+      observer = BW::App.notification_center.observe('ViewSuperView dealloc') do |obj|
         if obj.userInfo['tag'] == 1
           @weak_deallocated = true
         elsif obj.userInfo['tag'] == 2
@@ -96,7 +96,7 @@ describe BW::UIViewWrapper do
         v2 = ViewSuperView.new
         v2.tag = 2
       }
-      App.notification_center.unobserve(observer)
+      BW::App.notification_center.unobserve(observer)
       @weak_deallocated.should.equal true
       @strong_deallocated.should.equal nil
     end

--- a/spec/motion/util/constants_spec.rb
+++ b/spec/motion/util/constants_spec.rb
@@ -23,7 +23,7 @@ describe BubbleWrap::Constants do
       BW::Constants.get("NSStringEncodingConversion", :allow_lossy, :external_representation).should == (NSStringEncodingConversionAllowLossy | NSStringEncodingConversionExternalRepresentation)
     end
 
-    if App.ios?
+    if BW::App.ios?
       it "should return an array of string constant values" do
         BW::Constants.get("UIActivityType", [:air_drop, :print]).should == ["com.apple.UIKit.activity.AirDrop", "com.apple.UIKit.activity.Print"]
       end


### PR DESCRIPTION
I'd like to suggest that we remove the convenience of instantiating Device as BW::Device if it is not defined.

The reason why is that this causes a name spacing problem that forces you to handle your load paths, which can cause a lot of headaches. Since BubbleWrap has already been shorten to BW, typing BW::Device isn't too far from typing Device.

It will also prevent other gems that rely on BW to explicitly call BW::Device instead of assuming that Device is BW::Device.

What do you think? I'd love to hear your thoughts on it.

Thank you!
