### PR TITLE
Add support for Object#method to the Eventable module

### DIFF
--- a/motion/reactor/eventable.rb
+++ b/motion/reactor/eventable.rb
@@ -6,14 +6,16 @@ module BubbleWrap
       # When `event` is triggered the block will execute
       # and be passed the arguments that are passed to
       # `trigger`.
-      def on(event, &blk)
-        __events__[event].push blk
+      def on(event, method = nil, &blk)
+        method_or_block = method ? method : blk
+        __events__[event].push method_or_block
       end
 
       # When `event` is triggered, do not call the given
       # block any more
-      def off(event, &blk)
-        __events__[event].delete_if { |b| b == blk }
+      def off(event, method = nil, &blk)
+        method_or_block = method ? method : blk
+        __events__[event].delete_if { |b| b == method_or_block }
         blk
       end
 


### PR DESCRIPTION
Hello!
I make heavy use of the Eventable module, and sometimes I find it useful to re-use some methods as events. It looks similar to this:

``` ruby
object.on :my_event, &method(:my_method)
```

However, Method#to_proc returns a different object each time, and this makes it difficult to unbind the event when the VC gets deallocated. This is easily solved by passing a simple Method object

``` ruby
object.on :my_event, method(:my_method)
```

My implementation is backwards compatible with the existing one so it shouldn't cause any problem to existing apps.

Also, be aware that the current test suite fails, as Object#method leaks. This bug has been reported and will be fixed in the next RM release (http://hipbyte.myjetbrains.com/youtrack/issue/RM-456).
