### PR TITLE
Add Archive functionality to BW::Persistence

### DIFF
--- a/motion/core/persistence.rb
+++ b/motion/core/persistence.rb
@@ -52,6 +52,68 @@ module BubbleWrap
       end
       new_hash
     end
+
+    module Archive
+      module_function
+
+      SUPPORTED_CLASSES = [TrueClass, FalseClass, NSData, NSString, NSNumber, NSDate, NSArray, NSDictionary]
+
+      def []=(key, value)
+        BubbleWrap::Persistence[key] = pack_archive(value)
+      end
+
+      def [](key)
+        unpack_archive(BubbleWrap::Persistence[key])
+      end
+
+      def pack_archive(object)
+        case object
+        when Array
+          object.map{|item| pack_archive(item)}
+        when Hash
+          object.inject({}) do |result, (key, value)|
+            result[pack_archive(key)] = pack_archive(value)
+            result
+          end
+        when NSData, NSCFData
+          raise "Can't store NSData objects in BubbleWrap::Persistence::Archive"
+        when *SUPPORTED_CLASSES
+          object
+        else  
+          NSKeyedArchiver.archivedDataWithRootObject(object)
+        end
+      end
+
+      def unpack_archive(object)
+        case object
+        when Array
+          object.map{|item| unpack_archive(item)}
+        when Hash
+          object.inject({}) do |result, (key, value)|
+            result[unpack_archive(key)] = unpack_archive(value)
+            result
+          end
+        when NSData, NSCFData
+          NSKeyedUnarchiver.unarchiveObjectWithData(object)
+        else
+          # RubyMotion currently has a bug where the strings returned from
+          # standardUserDefaults are missing some methods (e.g. to_data).
+          # And because the returned object is slightly different than a normal
+          # String, we can't just use `value.is_a?(String)`
+
+          if object.class.to_s == 'String'
+            object.dup
+          else
+            object
+          end
+        end
+      end
+
+      def supported_class?(object)
+        SUPPORTED_CLASSES.find { |supported_class| object.kind_of?(supported_class) }
+      end
+
+    end
   end
 
 end


### PR DESCRIPTION
This PR adds the Archive module to Persistence. It simplifies storing objects that need `NSKeyArchiver`. The class of the object still needs to implement the NSCoding methods, but other than that you can simply do:

``` ruby
BW::Persistence::Archive[:my_object] = an_object
# And retrieve...
an_object = BW::Persistence::Archive[:my_object]
```

Instead of doing the NSKeyArchiver dance. This also works with Arrays and Hashes of objects, which are converted to Arrays and Hashes of archived objects respectively:

``` ruby
BW::Persistence::Archive[:my_object] = [object1, object2, 123, object4]
BW::Persistence::Archive[:some_hash] = {first: object1, second: object2, third: [object4, object5]}
```

This will recursively use NSKeyArchiver to convert all objects to NSUserDefaults-compatible types (i.e. it'll keep Strings and Numbers as Strings and Numbers, but convert any other object to NSData if they do NSCoding).

It's compatible with normal BW::Persistence (or indeed NSUserDefaults) usage. For example after the previous two lines, you could do this to retrieve the stored number:

``` ruby
BW::Persistence[:my_object][2] == 123 # true
```

The reason this cannot (probably) be implemented by default in BW::Persistence is that we don't know beforehand if the user stored NSData or an object that is archived to NSData, so we don't know whether to unarchive it or not.

We could make the convention that any NSData in BW::Persistence should be unarchived, and that you can't retrieve NSData from BW::Persistence without specifying you don't want it to be unarchived. We could also try to unarchive all NSData and only when NSKeyArchiver throws an exception return the raw NSData.

This merits a discussion.
