### PR TITLE
Allow passing multiple key paths to #observe

### DIFF
--- a/motion/core/kvo.rb
+++ b/motion/core/kvo.rb
@@ -29,8 +29,14 @@ module BubbleWrap
       key_path = arguments.pop
       target   = arguments.pop || self
 
-      target.addObserver(self, forKeyPath:key_path, options:DEFAULT_OPTIONS, context:nil) unless registered?(target, key_path)
-      add_observer_block(target, key_path, &block)
+      if key_path.is_a?(Array)
+        key_path.each do |path|
+          observe(target, path, &block)
+        end
+      else
+        target.addObserver(self, forKeyPath:key_path, options:DEFAULT_OPTIONS, context:nil) unless registered?(target, key_path)
+        add_observer_block(target, key_path, &block)
+      end
     end
 
     def unobserve(*arguments)
@@ -41,10 +47,16 @@ module BubbleWrap
       key_path = arguments.pop
       target   = arguments.pop || self
 
-      return unless registered?(target, key_path)
+      if key_path.is_a?(Array)
+        key_path.each do |path|
+          unobserve(target, path)
+        end
+      else
+        return unless registered?(target, key_path)
 
-      target.removeObserver(self, forKeyPath:key_path)
-      remove_observer_block(target, key_path)
+        target.removeObserver(self, forKeyPath:key_path)
+        remove_observer_block(target, key_path)
+      end
     end
 
     def unobserve_all

--- a/spec/motion/core/kvo_spec.rb
+++ b/spec/motion/core/kvo_spec.rb
@@ -45,6 +45,10 @@ describe BubbleWrap::KVO do
       unobserve(@label, method)
     end
 
+    def update_collection
+      self.items += [ "Rice" ]
+    end
+
     #  def unobserve_all
     #unobserve(@label, "text")
     #unobserve(self, "items")
@@ -214,7 +218,36 @@ describe BubbleWrap::KVO do
       @example.age = 2
       observed.should == false
     end
-  
+
+    # with multiple keypaths
+
+    it "should observe multiple key paths" do
+      observed = 0
+      @example.observe [:age, :items] do
+        observed += 1
+      end
+
+      @example.age = 2
+      @example.age = 3
+      @example.update_collection
+
+      observed.should.be == 3
+    end
+
+    it "should unobserve multiple key paths" do
+      observed = 0
+
+      @example.observe [:age, :items] do
+        observed += 1
+      end
+
+      @example.unobserve [:age]
+
+      @example.age = 2
+      @example.update_collection
+
+      observed.should.be == 1
+    end
   end
  
 =begin


### PR DESCRIPTION
This PR adds the ability to observe multiple keypaths with the same call/block:

```ruby
observe @obj, [:name, :age, :location] do
  update_description
end
```

This will call that block if either one of the three keypaths change.

Right now this is implemented using a trivial loop over the original #observe call so the block is only passed `old_value` and `new_value`, but maybe we should change the structure so that it passes the keypath that changed into the block as well, so we could do this:

```ruby
observe @obj, [:name, :age, :location] do |old_value, new_value, key_path|
  puts "#{key_path} changed from #{old_value} to #{new_value}"
end
```