### PR TITLE
fix for when_pressed and uiactionsheet

### DIFF
--- a/motion/ui/ui_view_wrapper.rb
+++ b/motion/ui/ui_view_wrapper.rb
@@ -25,7 +25,7 @@ module BubbleWrap
     end
 
     def when_pressed(enableInteraction=true, &proc)
-      add_gesture_recognizer_helper(UILongPressGestureRecognizer.alloc.initWithTarget(self, action:'handle_gesture:'), enableInteraction, proc)
+      add_gesture_recognizer_helper(UILongPressGestureRecognizer.alloc.initWithTarget(self, action:'handle_gesture_pressed_on_begin:'), enableInteraction, proc)
     end
 
     def self.deprecated_methods
@@ -43,6 +43,12 @@ module BubbleWrap
 
     def handle_gesture(recognizer)
       @recognizers[recognizer].call(recognizer)
+    end
+
+    def handle_gesture_pressed_on_begin(recognizer)
+      if recognizer.state==UIGestureRecognizerStateBegan
+        @recognizers[recognizer].call(recognizer)
+      end
     end
 
     # Adds the recognizer and keeps a strong reference to the Proc object.


### PR DESCRIPTION
without checking for recognizer.state==UIGestureRecognizerStateBegan, if you call a new UIActionSheet from inside a when_pressed handler two identical `UIActionSheet`s are instantiated and displayed:

```
view.when_pressed do
    UIActionSheet.alert("Log out?", buttons: ['Cancel', "Log out"]) do |pressed|
      if pressed=="Log out"
        #do something
      end
    end        
end
```

this update fixes `when_pressed` to work as expected. that is, to only show a single UIActionSheet when the above code is executed.

see also: http://stackoverflow.com/questions/15363311/uigesturerecognizerstatebegan-calling-twice-in-ios-6
