### PR TITLE
Update .gemspec description to mention RubyMotion is for OS X too

### DIFF
--- a/bubble-wrap.gemspec
+++ b/bubble-wrap.gemspec
@@ -4,8 +4,8 @@ require File.expand_path('../lib/bubble-wrap/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.authors       = ['Matt Aimonetti', 'Francis Chong', 'James Harton', 'Clay Allsopp', 'Dylan Markow', 'Jan Weinkauff', 'Marin Usalj']
   gem.email         = ['mattaimonetti@gmail.com', 'francis@ignition.hk', 'james@sociable.co.nz', 'clay.allsopp@gmail.com', 'dylan@dylanmarkow.com', 'jan@dreimannzelt.de', 'mneorr@gmail.com']
-  gem.description   = 'RubyMotion wrappers and helpers (Ruby for iOS) - Making Cocoa APIs more Ruby like, one API at a time. Fork away and send your pull request.'
-  gem.summary       = 'RubyMotion wrappers and helpers (Ruby for iOS) - Making Cocoa APIs more Ruby like, one API at a time. Fork away and send your pull request.'
+  gem.description   = 'RubyMotion wrappers and helpers (Ruby for iOS and OS X) - Making Cocoa APIs more Ruby like, one API at a time. Fork away and send your pull request.'
+  gem.summary       = 'RubyMotion wrappers and helpers (Ruby for iOS and OS X) - Making Cocoa APIs more Ruby like, one API at a time. Fork away and send your pull request.'
   gem.homepage      = 'http://rubymotion.github.io/BubbleWrap/'
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
Would be good if someone helps to update the Github repository description too, to:

“Cocoa wrappers and helpers for RubyMotion (Ruby for iOS and OS X) - Making Cocoa APIs more Ruby like, one API at a time. Fork away and send your pull requests”
