### PR TITLE
Fix memory leak in eventable __events__ hash

### DIFF
--- a/motion/reactor/eventable.rb
+++ b/motion/reactor/eventable.rb
@@ -7,21 +7,23 @@ module BubbleWrap
       # and be passed the arguments that are passed to
       # `trigger`.
       def on(event, method = nil, &blk)
+        events = _events_for_key(event)
         method_or_block = method ? method : blk
-        __events__[event].push method_or_block
+        events.push method_or_block
       end
 
       # When `event` is triggered, do not call the given
       # block any more
       def off(event, method = nil, &blk)
+        events = _events_for_key(event)
         method_or_block = method ? method : blk
-        __events__[event].delete_if { |b| b == method_or_block }
+        events.delete_if { |b| b == method_or_block }
         blk
       end
 
       # Trigger an event
       def trigger(event, *args)
-        blks = __events__[event].clone
+        blks = _events_for_key(event).clone
         blks.map do |blk|
           blk.call(*args)
         end
@@ -30,7 +32,11 @@ module BubbleWrap
       private
 
       def __events__
-        @__events__ ||= Hash.new { |h,k| h[k] = [] }
+        @__events__ ||= Hash.new
+      end
+
+      def _events_for_key(event)
+        __events__[event] ||= Array.new
       end
     end
   end


### PR DESCRIPTION
Based off of a current leak in rubymotion(http://hipbyte.myjetbrains.com/youtrack/issue/RM-534), I have fixed a leak in the eventable module.  Creating the hash of events as it was

```
@__events__ ||= Hash.new { |h,k| h[k] = [] }
```

will create a circular retain, and the object will never be deallocated.  Removing the proc after Hash.new resolves the issue.
