### PR TITLE
Eventable .off fix when using method(:my_method) syntax

### DIFF
--- a/motion/reactor/eventable.rb
+++ b/motion/reactor/eventable.rb
@@ -16,8 +16,11 @@ module BubbleWrap
       # block any more
       def off(event, method = nil, &blk)
         events = _events_for_key(event)
-        method_or_block = method ? method : blk
-        events.delete_if { |b| b == method_or_block }
+        if method
+          events.delete_if { |m| m.receiver == method.receiver and m.name == method.name }
+        else
+          events.delete_if { |b| b == blk }
+        end
         blk
       end
 

--- a/spec/motion/reactor/eventable_spec.rb
+++ b/spec/motion/reactor/eventable_spec.rb
@@ -48,6 +48,21 @@ describe BubbleWrap::Reactor::Eventable do
       events[:foo].member?(proof).should == false
     end
 
+    it 'unregisters method events after kvo' do
+      observing_object = Class.new do
+        include BubbleWrap::KVO
+      end.new
+
+      @subject.on(:foo, @subject.method(:description))
+      block = lambda { |old_value, new_value| }
+      observing_object.observe(@subject, :cool_variable, &block)
+      @subject.off(:foo, @subject.method(:description))
+
+      events = @subject.instance_variable_get(:@__events__)
+      events[:foo].length.should == 0
+      observing_object.unobserve_all
+    end
+
     it 'calls other event procs when a proc unregisters itself' do
       @proxy.proof = 0
       proof1 = proc do |r|


### PR DESCRIPTION
This PR contains a memory fix from PR(https://github.com/rubymotion/BubbleWrap/pull/398).  Using ruby's method ==(http://ruby-doc.org/core-2.1.2/Method.html#method-i-3D-3D) is too strict when also using BubbleWrap::KVO.

From ruby-doc.org:

> Two method objects are equal if they are bound to the same object and refer to the same method definition and their owners are the same class or module.

If you begin observing an object after creating an event with a method(:), it can change the owner property of method(:) when you go to take off the event.

This change relaxes the definition of == for method objects for removal.
