### PR TITLE
Remove strongly held target from kvo targets hash

### DIFF
--- a/motion/core/kvo.rb
+++ b/motion/core/kvo.rb
@@ -53,7 +53,7 @@ module BubbleWrap
       @targets.each do |target, key_paths|
         key_paths.each_key do |key_path|
           target.removeObserver(self, forKeyPath:key_path)
-        end  
+        end
       end
       remove_all_observer_blocks
     end
@@ -81,6 +81,9 @@ module BubbleWrap
 
       key_paths = @targets[target]
       key_paths.delete(key_path.to_s) if !key_paths.nil?
+      if key_paths.nil? || key_paths.length == 0
+        @targets.delete(target)
+      end
     end
 
     def remove_all_observer_blocks

--- a/spec/motion/core/kvo_spec.rb
+++ b/spec/motion/core/kvo_spec.rb
@@ -100,7 +100,7 @@ describe BubbleWrap::KVO do
       @example.send(:remove_observer_block, nil, "key_path")
       @example.send(:registered?, target, "key_path").should == true
     end
-  
+
     it "should not remove an observer block if the key path is not present" do
       target = Object.new
       block = lambda { |old_value, new_value| }
@@ -108,7 +108,7 @@ describe BubbleWrap::KVO do
       @example.send(:remove_observer_block, target, nil)
       @example.send(:registered?, target, "key_path").should == true
     end
-  
+
     it "should remove only one observer block" do
       target = Object.new
       block = lambda { |old_value, new_value| }
@@ -118,9 +118,9 @@ describe BubbleWrap::KVO do
       @example.send(:registered?, target, "key_path1").should == false
       @example.send(:registered?, target, "key_path2").should == true
     end
-  
+
     # remove all
-  
+
     it "should remove all observer blocks" do
       target = Object.new
       block = lambda { |old_value, new_value| }
@@ -128,21 +128,38 @@ describe BubbleWrap::KVO do
       @example.send(:add_observer_block, target, "key_path2", &block)
       @example.send(:remove_all_observer_blocks)
       @example.send(:registered?, target, "key_path1").should == false
-      @example.send(:registered?, target, "key_path2").should == false    
+      @example.send(:registered?, target, "key_path2").should == false
     end
-    
+
+    it "should remove target from targets if no observers remain" do
+      target = Object.new
+      block = lambda { |old_value, new_value| }
+      @example.send(:add_observer_block, target, "key_path", &block)
+      @example.send(:remove_observer_block, target, "key_path")
+      @example.instance_variable_get(:@targets).length.should == 0
+    end
+
+    it "should not remove target from targets if observers remain" do
+      target = Object.new
+      block = lambda { |old_value, new_value| }
+      @example.send(:add_observer_block, target, "key_path1", &block)
+      @example.send(:add_observer_block, target, "key_path2", &block)
+      @example.send(:remove_observer_block, target, "key_path1")
+      @example.instance_variable_get(:@targets).length.should > 0
+    end
+
   end
-  
+
   describe "API" do
     before do
       @example = KvoExample.new
     end
-  
+
     after do
       @example.unobserve_all
       @example = nil
     end
-    
+
     # observe
 
     it "should observe a key path" do
@@ -152,11 +169,11 @@ describe BubbleWrap::KVO do
         old_value.should == "Foo"
         new_value.should == "Bar"
       end
-    
+
       @example.set_text "Bar"
       observed.should == true
     end
-  
+
     it "should observe a key path with more than one block" do
       observed_one = false
       observed_two = false
@@ -170,22 +187,22 @@ describe BubbleWrap::KVO do
       @example.observe_label do |old_value, new_value|
         observed_three = true
       end
-    
+
       @example.set_text "Bar"
       observed_one.should == true
       observed_two.should == true
       observed_three.should == true
     end
-    
+
     # unobserve
-    
+
     it "should unobserve a key path" do
       observed = false
       @example.observe_label do |old_value, new_value|
         observed = true
       end
       @example.unobserve_label
-    
+
       @example.set_text "Bar"
       observed.should == false
     end
@@ -199,7 +216,7 @@ describe BubbleWrap::KVO do
         old_value.should == 1
         new_value.should == 2
       end
-    
+
       @example.age = 2
       observed.should == true
     end
@@ -210,13 +227,13 @@ describe BubbleWrap::KVO do
         observed = true
       end
       @example.unobserve :age
-    
+
       @example.age = 2
       observed.should == false
     end
-  
+
   end
- 
+
 =begin
   it "should be able to observe a collection" do
     observed = false
@@ -224,9 +241,9 @@ describe BubbleWrap::KVO do
       puts "#{collection} #{old_value} #{new_value} #{indexes}"
       observed = true
     end
-    
+
     @example.items << "Dragonfruit"
-    observed.should == true  
+    observed.should == true
   end
 =end
 


### PR DESCRIPTION
This issue seems to also be resolved in this PR(https://github.com/rubymotion/BubbleWrap/pull/361), but has not been merged in yet. This PR resolves only the issue I ran into. I think keeping a strong reference in @targets is okay, as long as it is removed when no longer needed. The way it currently is, the target object will only be released when the observing object is also released(releasing @targets)
