### PR TITLE
Change location constants to register only if ios constants exist. Allows ios7/xcode5 apps to build against repo

### DIFF
--- a/motion/location/location.rb
+++ b/motion/location/location.rb
@@ -27,7 +27,8 @@ module BubbleWrap
 
     # New additions to CLAuthorizationStatus in ios8
     # see: https://developer.apple.com/library/prerelease/ios/documentation/CoreLocation/Reference/CLLocationManager_Class/index.html#//apple_ref/c/tdef/CLAuthorizationStatus
-    Constants.register KCLAuthorizationStatusAuthorizedWhenInUse, KCLAuthorizationStatusAuthorizedAlways
+    Constants.register(KCLAuthorizationStatusAuthorizedWhenInUse) if defined? KCLAuthorizationStatusAuthorizedWhenInUse
+    Constants.register(KCLAuthorizationStatusAuthorizedAlways) if defined? KCLAuthorizationStatusAuthorizedAlways
 
     module_function
     # Start getting locations

--- a/spec/motion/location/location_spec.rb
+++ b/spec/motion/location/location_spec.rb
@@ -66,6 +66,7 @@ def reset
 end
 
 describe BubbleWrap::Location do
+
   describe ".get" do
     before do
       reset
@@ -79,25 +80,33 @@ describe BubbleWrap::Location do
     end
 
     it "should return false when not available" do
-      CLLocationManager.authorize(KCLAuthorizationStatusNotDetermined)
-      BW::Location.authorized?.should == false
+      if defined?(KCLAuthorizationStatusAuthorizedAlways)
+        CLLocationManager.authorize(KCLAuthorizationStatusNotDetermined)
+        BW::Location.authorized?.should == false
 
-      CLLocationManager.authorize(KCLAuthorizationStatusRestricted)
-      BW::Location.authorized?.should == false
+        CLLocationManager.authorize(KCLAuthorizationStatusRestricted)
+        BW::Location.authorized?.should == false
 
-      CLLocationManager.authorize(KCLAuthorizationStatusDenied)
-      BW::Location.authorized?.should == false
+        CLLocationManager.authorize(KCLAuthorizationStatusDenied)
+        BW::Location.authorized?.should == false
+      else
+        true.should == true
+      end
     end
 
     it "should return true when available" do
-      CLLocationManager.authorize(KCLAuthorizationStatusAuthorized)
-      BW::Location.authorized?.should == true
+      if defined?(KCLAuthorizationStatusAuthorizedAlways)
+        CLLocationManager.authorize(KCLAuthorizationStatusAuthorized)
+        BW::Location.authorized?.should == true
 
-      CLLocationManager.authorize(KCLAuthorizationStatusAuthorizedWhenInUse)
-      BW::Location.authorized?.should == true
+        CLLocationManager.authorize(KCLAuthorizationStatusAuthorizedWhenInUse)
+        BW::Location.authorized?.should == true
 
-      CLLocationManager.authorize(KCLAuthorizationStatusAuthorizedAlways)
-      BW::Location.authorized?.should == true
+        CLLocationManager.authorize(KCLAuthorizationStatusAuthorizedAlways)
+        BW::Location.authorized?.should == true
+      else
+        true.should == true
+      end
     end
 
     it "should throw error if not enabled" do


### PR DESCRIPTION
This PR probably only makes sense for a few months, but for now, it allows users to use the latest and greatest bubblewrap on ios7.