### PR TITLE
Clarified documentation on strong references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-git@github.com:buffpojken/BubbleWrap.git# BubbleWrap for RubyMotion
+# BubbleWrap for RubyMotion
 
 A collection of (tested) helpers and wrappers used to wrap Cocoa Touch and AppKit code and provide more Ruby like APIs.
 


### PR DESCRIPTION
For beginners, the documentation is not clear that even when only using when_tapped and friends and not using UIControl#when - use_weak_callbacks is required to prevent leaks.
