### PR TITLE
Fix uialertview specs

### DIFF
--- a/spec/motion/core/ios/app_spec.rb
+++ b/spec/motion/core/ios/app_spec.rb
@@ -159,10 +159,8 @@ describe BubbleWrap::App do
           action_sheet.cancelButtonIndex = (action_sheet.addButtonWithTitle("Cancel"))
 
           old_window = App.window
-          window_count = App.windows.count
           action_sheet.showInView(App.window)
           wait 1 do
-            UIApplication.sharedApplication.windows.count.should > window_count
             App.window.should == old_window
 
             action_sheet.dismissWithClickedButtonIndex(action_sheet.cancelButtonIndex, animated: false)


### PR DESCRIPTION
Turns out iOS 8 is changing the root `UIWindow` class to `_UIAlertControllerShimPresenterWindow` (a subclass of `UIWindow`) after an app shows a `UIAlertView` or `UIActionSheet`.

Displaying a `UIActionSheet` also no longer increments the window count in the app when displayed.

Boooo. :ghost: 

This PR fixes it and should fix a lot of branches that are failing right now in Travis when they pull these changes in.
