### PR TITLE
Uicontrol event symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,6 +750,26 @@ button.when(UIControlEventTouchUpInside) do
 end
 ```
 
+The `#when` method also accepts bitwise combinations of events:
+
+```ruby
+button.when(UIControlEventTouchUpInside | UIControlEventTouchUpOutside) do
+  self.view.backgroundColor = UIColor.redColor
+end
+```
+
+You can use symbols for events (but won't work with the bitwise operator):
+
+```ruby
+button.when(:touch_up_inside) do
+  self.view.backgroundColor = UIColor.redColor
+end
+
+button.when(:value_changed) do
+  self.view.backgroundColor = UIColor.blueColor
+end
+```
+
 Set the use_weak_callbacks flag so the blocks do not retain a strong reference to self:
 
 ```ruby

--- a/motion/ui/ui_control_wrapper.rb
+++ b/motion/ui/ui_control_wrapper.rb
@@ -1,6 +1,8 @@
 module BubbleWrap
   module UIControlWrapper
     def when(events, options = {}, &block)
+      events = BW::Constants.get("UIControlEvent", events)
+
       @callback ||= {}
       @callback[events] ||= []
 
@@ -14,4 +16,29 @@ module BubbleWrap
       addTarget(@callback[events].last, action:'call', forControlEvents: events)
     end
   end
+
+  Constants.register(
+    UIControlEventTouchDown,
+    UIControlEventTouchDownRepeat,
+    UIControlEventTouchDragInside,
+    UIControlEventTouchDragOutside,
+    UIControlEventTouchDragEnter,
+    UIControlEventTouchDragExit,
+    UIControlEventTouchUpInside,
+    UIControlEventTouchUpOutside,
+    UIControlEventTouchCancel,
+
+    UIControlEventValueChanged,
+
+    UIControlEventEditingDidBegin,
+    UIControlEventEditingChanged,
+    UIControlEventEditingDidEnd,
+    UIControlEventEditingDidEndOnExit,
+
+    UIControlEventAllTouchEvents,
+    UIControlEventAllEditingEvents,
+    # UIControlEventApplicationReserved,
+    # UIControlEventSystemReserved,
+    UIControlEventAllEvents
+  )
 end

--- a/spec/motion/ui/ui_control_wrapper_spec.rb
+++ b/spec/motion/ui/ui_control_wrapper_spec.rb
@@ -69,5 +69,14 @@ describe BW::UIControlWrapper do
       @subject.sendActionsForControlEvents(UIControlEventTouchUpInside)
       @touched.should.equal ['for the very first time', 'touched']
     end
+
+    it "allows symbols for actions" do
+      @subject.when(:touch_up_inside) do
+        @touched << 'touched'
+      end
+
+      @subject.sendActionsForControlEvents(UIControlEventTouchUpInside)
+      @touched.should.equal ['touched']
+    end
   end
 end

--- a/spec/motion/ui/ui_control_wrapper_spec.rb
+++ b/spec/motion/ui/ui_control_wrapper_spec.rb
@@ -23,6 +23,21 @@ describe BW::UIControlWrapper do
       @touched.should.equal ['touched']
     end
 
+    it "allows bitwise operators" do
+      @subject.when(UIControlEventTouchUpInside | UIControlEventTouchUpOutside) do
+        @touched << 'touched'
+      end
+
+      @subject.sendActionsForControlEvents(UIControlEventTouchUpInside)
+      @touched.should.equal ['touched']
+
+      @touched = []
+      @touched.should.equal []
+
+      @subject.sendActionsForControlEvents(UIControlEventTouchUpOutside)
+      @touched.should.equal ['touched']
+    end
+
     it "BubbleWrap.use_weak_callbacks=true removes cyclic references" do
       class ControlSuperView < UIView
         def initWithFrame(frame)


### PR DESCRIPTION
Adds the ability to use symbols in UIControl `when` events. Also adds a test to ensure that bitwise events can be chained together. Plus documentation.