### PR TITLE
Adds placeholder ability for plain text input

### DIFF
--- a/motion/ui/ui_alert_view.rb
+++ b/motion/ui/ui_alert_view.rb
@@ -49,7 +49,9 @@ module BW
         options = {buttons: ["Cancel", "OK"],
                    cancel_button_index: 0}.merge!(options)
         options[:style] = :plain_text_input
-        new(options, &block)
+        new(options, &block).tap do |view|
+          view.textFieldAtIndex(0).placeholder = options[:placeholder] if options[:placeholder]
+        end
       end
 
       def secure_text_input(options = {}, &block)

--- a/spec/motion/ui/ui_alert_view_spec.rb
+++ b/spec/motion/ui/ui_alert_view_spec.rb
@@ -185,6 +185,7 @@ describe BW::UIAlertView do
           :title                      => "title",
           :message                    => "message",
           :style                      => :plain_text_input,
+          :placeholder                => "placeholder",
           :buttons                    => "button title",
           :cancel_button_index        => 0,
           :will_present               => -> { true },
@@ -312,6 +313,7 @@ describe BW::UIAlertView do
           :title                      => "title",
           :message                    => "message",
           :style                      => :plain_text_input,
+          :placeholder                => "placeholder",
           :buttons                    => "button title",
           :cancel_button_index        => 0,
           :will_present               => -> { true },
@@ -403,6 +405,10 @@ describe BW::UIAlertView do
         @subject.plain_text_field.should.be.kind_of(UITextField)
       end
 
+      it "has no placeholder" do
+        @subject.plain_text_field.placeholder.should.be.nil
+      end
+
       it "has no secure text field" do
         @subject.secure_text_field.should.be.nil
       end
@@ -416,6 +422,20 @@ describe BW::UIAlertView do
       end
     end
 
+    ###############################################################################################
+
+    describe "given a text placeholder" do
+      before do
+        @options = {placeholder: "placeholder"}
+        @subject = BW::UIAlertView.plain_text_input(@options)
+      end
+
+      behaves_like "an instance with no options"
+
+      it "has the correct placeholder" do
+        @subject.plain_text_field.placeholder.should == "placeholder"
+      end
+    end
     ###############################################################################################
 
     describe "given no options with a block" do
@@ -454,6 +474,7 @@ describe BW::UIAlertView do
           :title                      => "title",
           :message                    => "message",
           :style                      => :default,
+          :placeholder                => "placeholder",
           :buttons                    => "button title",
           :cancel_button_index        => 0,
           :will_present               => -> { true },
@@ -596,6 +617,7 @@ describe BW::UIAlertView do
           :title                      => "title",
           :message                    => "message",
           :style                      => :default,
+          :placeholder                => "placeholder",
           :buttons                    => "button title",
           :cancel_button_index        => 0,
           :will_present               => -> { true },
@@ -738,6 +760,7 @@ describe BW::UIAlertView do
           :title                      => "title",
           :message                    => "message",
           :style                      => :default,
+          :placeholder                => "placeholder",
           :buttons                    => "button title",
           :cancel_button_index        => 0,
           :will_present               => -> { true },


### PR DESCRIPTION
Pass `:placeholder` in an alert view options hash for a plain text input alert to have a placeholder on the text field.