### PR TITLE
UIViewWrapper#when_pressed: should use #handle_gesture: like all the other #when_XXX: methods and not check for UIGestureRecognizerStateBegan.

### DIFF
--- a/motion/ui/ui_view_wrapper.rb
+++ b/motion/ui/ui_view_wrapper.rb
@@ -25,7 +25,7 @@ module BubbleWrap
     end
 
     def when_pressed(enableInteraction=true, &proc)
-      add_gesture_recognizer_helper(UILongPressGestureRecognizer.alloc.initWithTarget(self, action:'handle_gesture_pressed_on_begin:'), enableInteraction, proc)
+      add_gesture_recognizer_helper(UILongPressGestureRecognizer.alloc.initWithTarget(self, action:'handle_gesture:'), enableInteraction, proc)
     end
 
     def self.deprecated_methods
@@ -43,12 +43,6 @@ module BubbleWrap
 
     def handle_gesture(recognizer)
       @recognizers[recognizer].call(recognizer)
-    end
-
-    def handle_gesture_pressed_on_begin(recognizer)
-      if recognizer.state==UIGestureRecognizerStateBegan
-        @recognizers[recognizer].call(recognizer)
-      end
     end
 
     # Adds the recognizer and keeps a strong reference to the Proc object.


### PR DESCRIPTION
UIViewWrapper#when_pressed: should use #handle_gesture: like all the other #when_XXX: methods and not check for UIGestureRecognizerStateBegan. The check should be left to the caller.

Both for consistency of API and support for this use case:

(1) long press - do something
(2) release long press - do another thing.

This was how it worked until it was changed in e66dc51a790c8470ba8f748291c69dd0bcb2745.