### PR TITLE
Added edge param to when_screen_edge_panned method

### DIFF
--- a/motion/ui/ui_view_wrapper.rb
+++ b/motion/ui/ui_view_wrapper.rb
@@ -20,8 +20,10 @@ module BubbleWrap
       add_gesture_recognizer_helper(UIPanGestureRecognizer.alloc.initWithTarget(self, action:'handle_gesture:'), enableInteraction, proc)
     end
 
-    def when_screen_edge_panned(enableInteraction=true, &proc)
-      add_gesture_recognizer_helper(UIScreenEdgePanGestureRecognizer.alloc.initWithTarget(self, action:'handle_gesture:'), enableInteraction, proc)
+    def when_screen_edge_panned(enableInteraction=true, edge=UIRectEdgeRight, &proc)
+      gesture_recognizer = UIScreenEdgePanGestureRecognizer.alloc.initWithTarget(self, action:'handle_gesture:')
+      gesture_recognizer.edges = edge
+      add_gesture_recognizer_helper(gesture_recognizer, enableInteraction, proc)
     end
 
     def when_pressed(enableInteraction=true, &proc)


### PR DESCRIPTION
When using UIScreenEdgePanGestureRecognizer we need to set the edge after initialization. Added the option to pass the edge to the method. All tests are still passing.
