### PR TITLE
Allow Eventable#off to remove all handlers

### DIFF
--- a/motion/reactor/eventable.rb
+++ b/motion/reactor/eventable.rb
@@ -18,8 +18,10 @@ module BubbleWrap
         events = _events_for_key(event)
         if method
           events.delete_if { |m| m.receiver == method.receiver and m.name == method.name }
-        else
+        elsif blk
           events.delete_if { |b| b == blk }
+        else
+          __events__[event] = Array.new
         end
         blk
       end

--- a/spec/motion/reactor/eventable_spec.rb
+++ b/spec/motion/reactor/eventable_spec.rb
@@ -48,6 +48,17 @@ describe BubbleWrap::Reactor::Eventable do
       events[:foo].member?(proof).should == false
     end
 
+    it 'unregisters all events' do
+      def bar; end
+      proof = method(:bar)
+      @subject.on(:foo, proof)
+      proof_2 = proc { }
+      @subject.on(:foo, &proof_2)
+      events = @subject.instance_variable_get(:@__events__)
+      @subject.off(:foo)
+      events[:foo].should == []
+    end
+
     it 'unregisters method events after kvo' do
       observing_object = Class.new do
         include BubbleWrap::KVO


### PR DESCRIPTION
This PR updates `Eventable#off` to remove all listeners for the given event if neither a method or a block is passed. This behavior is useful when the method or block that you've attached with `on()` has fallen out of scope, or if you're quite sure you want to stop handling a particular event altogether. 

In practice, the need for this behavior showed up when I was listening to a set of Eventables from UITableViewCell instances inside a UIPopoverController view. I needed to remove and re-add event listeners when the UITableViewCells were reused or the popover was closed and reopened. The Eventable instances were retained throughout, but the instances that were calling `on()` and `off()` were falling in and out of ruby scope. As such, I couldn't remove the block handlers, since the equality check driving the `delete_if` was failing. 

I'm not sure if this is a breaking change, since it doesn't seem that `off()` does anything when called this way currently. The specs pass, and I haven't noticed any adverse affects in our app, although there are no doubt many sides to BubbleWrap that we are not using.

Anyway, thanks for this great library! Please take a look and let me know if there's anything that needs updating with the PR or if it is a terrible idea for some reason.

Cheers,

Mark