### PR TITLE
Feature: `observe!` method for creating "initial" observer [+Bonus]

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,27 @@ class ExampleViewController < UIViewController
 end
 ```
 
+You can remove observers using `unobserve` method.
+
 **Since: > version 1.9.0**
+
+Optionally, multiple key paths can be passed to the `observer` method:
+
+``` ruby
+class ExampleViewController < UIViewController
+  include BW::KVO
+
+  def viewDidLoad
+    @label = UILabel.alloc.initWithFrame [[20,20],[280,44]]
+    @label.text = ""
+    view.addSubview @label
+
+    observe(@label, [:text, :textColor]) do |old_value, new_value, key_path|
+      puts "Hello from viewDidLoad for #{key_path}!"
+    end
+  end
+end
+```
 
 Also you can use `observe!` method to register observer that will immediately
 return initial value. Note that in this case only new value will be passed to

--- a/README.md
+++ b/README.md
@@ -388,6 +388,12 @@ class ExampleViewController < UIViewController
 end
 ```
 
+**Since: > version 1.9.0**
+
+Also you can use `observe!` method to register observer that will immediately
+return initial value. Note that in this case only new value will be passed to
+the block.
+
 
 ### String
 

--- a/motion/core/kvo.rb
+++ b/motion/core/kvo.rb
@@ -85,9 +85,11 @@ module BubbleWrap
     def observeValueForKeyPath(key_path, ofObject: target, change: change, context: context)
       key_paths = @targets[target] || {}
       blocks = key_paths[key_path] || []
+
+      args = [change[NSKeyValueChangeOldKey], change[NSKeyValueChangeNewKey]]
+      args << change[NSKeyValueChangeIndexesKey] if collection?(change)
+
       blocks.each do |block|
-        args = [change[NSKeyValueChangeOldKey], change[NSKeyValueChangeNewKey]]
-        args << change[NSKeyValueChangeIndexesKey] if collection?(change)
         block.call(*args)
       end
     end

--- a/motion/core/kvo.rb
+++ b/motion/core/kvo.rb
@@ -21,30 +21,20 @@ module BubbleWrap
     COLLECTION_OPERATIONS = [ NSKeyValueChangeInsertion, NSKeyValueChangeRemoval, NSKeyValueChangeReplacement ]
     DEFAULT_OPTIONS = NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
 
-    def observe(*arguments, &block)
-      unless [1,2].include?(arguments.length)
-        raise ArgumentError, "wrong number of arguments (#{arguments.length} for 1 or 2)"
+    def observe(target = self, key_path, &block)
+      if not registered?(target, key_path)
+        target.addObserver(self, forKeyPath:key_path, options:DEFAULT_OPTIONS, context:nil)
       end
 
-      key_path = arguments.pop
-      target   = arguments.pop || self
-
-      target.addObserver(self, forKeyPath:key_path, options:DEFAULT_OPTIONS, context:nil) unless registered?(target, key_path)
+      # Add block even if observer is registed, so multiplie blocks can be invoked.
       add_observer_block(target, key_path, &block)
     end
 
-    def unobserve(*arguments)
-      unless [1,2].include?(arguments.length)
-        raise ArgumentError, "wrong number of arguments (#{arguments.length} for 1 or 2)"
+    def unobserve(target = self, key_path)
+      if registered?(target, key_path)
+        target.removeObserver(self, forKeyPath:key_path)
+        remove_observer_block(target, key_path)
       end
-
-      key_path = arguments.pop
-      target   = arguments.pop || self
-
-      return unless registered?(target, key_path)
-
-      target.removeObserver(self, forKeyPath:key_path)
-      remove_observer_block(target, key_path)
     end
 
     def unobserve_all

--- a/spec/motion/core/kvo_spec.rb
+++ b/spec/motion/core/kvo_spec.rb
@@ -136,7 +136,7 @@ describe BubbleWrap::KVO do
       block = lambda { |old_value, new_value| }
       @example.send(:add_observer_block, target, "key_path", &block)
       @example.send(:remove_observer_block, target, "key_path")
-      @example.instance_variable_get(:@targets).length.should == 0
+      @example.send(:observer_blocks).length.should == 0
     end
 
     it "should not remove target from targets if observers remain" do
@@ -145,7 +145,7 @@ describe BubbleWrap::KVO do
       @example.send(:add_observer_block, target, "key_path1", &block)
       @example.send(:add_observer_block, target, "key_path2", &block)
       @example.send(:remove_observer_block, target, "key_path1")
-      @example.instance_variable_get(:@targets).length.should > 0
+      @example.send(:observer_blocks).length.should > 0
     end
 
   end

--- a/spec/motion/core/kvo_spec.rb
+++ b/spec/motion/core/kvo_spec.rb
@@ -11,29 +11,27 @@ describe BubbleWrap::KVO do
       @items = [ "Apple", "Banana", "Chickpeas" ]
       @age = 1
 
-      if App.osx?
-        @label = NSTextField.alloc.initWithFrame [[0,0],[320, 30]]
-        @label.stringValue = "Foo"
-      else
-        @label = UILabel.alloc.initWithFrame [[0,0],[320, 30]]
-        @label.text = "Foo"
-      end
+      @label = text_class.alloc.initWithFrame [[0,0],[320, 30]]
+
+      set_text "Foo"
     end
 
     # Test helper
 
     def get_text
-      App.osx? ? @label.stringValue : @label.text
+      @label.send(text_method_name)
     end
 
     def set_text(text)
-      method = App.osx? ? :stringValue : :text
-      @label.send("#{method}=", text)
+      @label.send("#{text_method_name}=", text)
     end
 
     def observe_label(&block)
-      method = App.osx? ? :stringValue : :text
-      observe(@label, method, &block)
+      observe(@label, text_method_name, &block)
+    end
+
+    def observe_label!(&block)
+      observe!(@label, text_method_name, &block)
     end
 
     def observe_collection(&block)
@@ -41,8 +39,19 @@ describe BubbleWrap::KVO do
     end
 
     def unobserve_label
-      method = App.osx? ? :stringValue : :text
-      unobserve(@label, method)
+      unobserve(@label, text_method_name)
+    end
+
+    def unobserve_label!
+      unobserve!(@label, text_method_name)
+    end
+
+    def text_method_name
+      App.osx? ? :stringValue : :text
+    end
+
+    def text_class
+      App.osx? ? NSTextField : UILabel
     end
 
     #  def unobserve_all
@@ -52,9 +61,9 @@ describe BubbleWrap::KVO do
 
   end
 
-  describe "Callbacks" do
+  describe "Registry" do
     before do
-      @example = KvoExample.new
+      @example = BW::KVO::Registry.new
     end
 
     after do
@@ -66,21 +75,21 @@ describe BubbleWrap::KVO do
     it "should add an observer block" do
       target = Object.new
       block = lambda { |old_value, new_value| }
-      @example.send(:add_observer_block, target, "key_path", &block)
-      @example.send(:registered?, target, "key_path").should == true
+      @example.add(target, "key_path", &block)
+      @example.registered?(target, "key_path").should == true
     end
 
     it "should not add an observer block if the key path is not present" do
       target = Object.new
       block = lambda { |old_value, new_value| }
-      @example.send(:add_observer_block, target, nil, &block)
-      @example.send(:registered?, target, nil).should == false
+      @example.add(target, nil, &block)
+      @example.registered?(target, nil).should == false
     end
 
     it "should not add an observer block if the block is not present" do
       target = Object.new
-      @example.send(:add_observer_block, target, "key_path")
-      @example.send(:registered?, target, "key_path").should == false
+      @example.add(target, "key_path")
+      @example.registered?(target, "key_path").should == false
     end
 
     # remove
@@ -88,35 +97,35 @@ describe BubbleWrap::KVO do
     it "should remove an observer block" do
       target = Object.new
       block = lambda { |old_value, new_value| }
-      @example.send(:add_observer_block, target, "key_path", &block)
-      @example.send(:remove_observer_block, target, "key_path")
-      @example.send(:registered?, target, "key_path").should == false
+      @example.add(target, "key_path", &block)
+      @example.remove(target, "key_path")
+      @example.registered?(target, "key_path").should == false
     end
 
     it "should not remove an observer block if the target is not present" do
       target = Object.new
       block = lambda { |old_value, new_value| }
-      @example.send(:add_observer_block, target, "key_path", &block)
-      @example.send(:remove_observer_block, nil, "key_path")
-      @example.send(:registered?, target, "key_path").should == true
+      @example.add(target, "key_path", &block)
+      @example.remove(nil, "key_path")
+      @example.registered?(target, "key_path").should == true
     end
 
     it "should not remove an observer block if the key path is not present" do
       target = Object.new
       block = lambda { |old_value, new_value| }
-      @example.send(:add_observer_block, target, "key_path", &block)
-      @example.send(:remove_observer_block, target, nil)
-      @example.send(:registered?, target, "key_path").should == true
+      @example.add(target, "key_path", &block)
+      @example.remove(target, nil)
+      @example.registered?(target, "key_path").should == true
     end
 
     it "should remove only one observer block" do
       target = Object.new
       block = lambda { |old_value, new_value| }
-      @example.send(:add_observer_block, target, "key_path1", &block)
-      @example.send(:add_observer_block, target, "key_path2", &block)
-      @example.send(:remove_observer_block, target, "key_path1")
-      @example.send(:registered?, target, "key_path1").should == false
-      @example.send(:registered?, target, "key_path2").should == true
+      @example.add(target, "key_path1", &block)
+      @example.add(target, "key_path2", &block)
+      @example.remove(target, "key_path1")
+      @example.registered?(target, "key_path1").should == false
+      @example.registered?(target, "key_path2").should == true
     end
 
     # remove all
@@ -124,28 +133,28 @@ describe BubbleWrap::KVO do
     it "should remove all observer blocks" do
       target = Object.new
       block = lambda { |old_value, new_value| }
-      @example.send(:add_observer_block, target, "key_path1", &block)
-      @example.send(:add_observer_block, target, "key_path2", &block)
-      @example.send(:remove_all_observer_blocks)
-      @example.send(:registered?, target, "key_path1").should == false
-      @example.send(:registered?, target, "key_path2").should == false
+      @example.add(target, "key_path1", &block)
+      @example.add(target, "key_path2", &block)
+      @example.remove_all
+      @example.registered?(target, "key_path1").should == false
+      @example.registered?(target, "key_path2").should == false
     end
 
     it "should remove target from targets if no observers remain" do
       target = Object.new
       block = lambda { |old_value, new_value| }
-      @example.send(:add_observer_block, target, "key_path", &block)
-      @example.send(:remove_observer_block, target, "key_path")
-      @example.send(:observer_blocks).length.should == 0
+      @example.add(target, "key_path", &block)
+      @example.remove(target, "key_path")
+      @example.callbacks.length.should == 0
     end
 
     it "should not remove target from targets if observers remain" do
       target = Object.new
       block = lambda { |old_value, new_value| }
-      @example.send(:add_observer_block, target, "key_path1", &block)
-      @example.send(:add_observer_block, target, "key_path2", &block)
-      @example.send(:remove_observer_block, target, "key_path1")
-      @example.send(:observer_blocks).length.should > 0
+      @example.add(target, "key_path1", &block)
+      @example.add(target, "key_path2", &block)
+      @example.remove(target, "key_path1")
+      @example.callbacks.length.should > 0
     end
 
   end
@@ -171,6 +180,16 @@ describe BubbleWrap::KVO do
       end
 
       @example.set_text "Bar"
+      observed.should == true
+    end
+
+    it "should immediately observe a key path" do
+      observed = false
+      @example.observe_label! do |new_value|
+        observed = true
+        new_value.should == nil
+      end
+
       observed.should == true
     end
 
@@ -205,6 +224,17 @@ describe BubbleWrap::KVO do
 
       @example.set_text "Bar"
       observed.should == false
+    end
+
+    it "should unobserve immediate observer" do
+      observed_times = 0
+      @example.observe_label do |old_value, new_value|
+        observed_times += 1
+      end
+      @example.unobserve_label!
+
+      @example.set_text "Bar"
+      observed_times.should == 1
     end
 
     # without target

--- a/spec/motion/core/kvo_spec.rb
+++ b/spec/motion/core/kvo_spec.rb
@@ -184,10 +184,12 @@ describe BubbleWrap::KVO do
     end
 
     it "should immediately observe a key path" do
+      @example.set_text "Foo"
+
       observed = false
       @example.observe_label! do |new_value|
         observed = true
-        new_value.should == nil
+        new_value.should == "Foo"
       end
 
       observed.should == true


### PR DESCRIPTION
This PR is adding `observe!` method that is in fact just creating observer with `NSKeyValueObservingOptionInitial` option. This method will help a lot with avoiding copying code form a block, when initial value must be set to receiver. 

Also I've done a minor refactoring: observers blocks registration logic extracted to separate class ``BW::KWO::Registry``. 