### PR TITLE
Remove double value

### DIFF
--- a/motion/rss_parser.rb
+++ b/motion/rss_parser.rb
@@ -44,7 +44,6 @@ module BubbleWrap
           :enclosure    => enclosure,
           :category     => category,
           :encoded      => encoded,
-          :enclosure    => enclosure
         }
       end
     end


### PR DESCRIPTION
Hi, this is a very little PR :) I just came across this line where `:enclosure` is being set twice. Tests are passing so I hope `:enclosure` it isn't done by purpose.