### PR TITLE
Updated Device.simulator? to work in iOS 13+

### DIFF
--- a/motion/core/ios/device.rb
+++ b/motion/core/ios/device.rb
@@ -46,7 +46,7 @@ module BubbleWrap
     def simulator?
       @simulator_state ||= begin
         if ios_version.to_i >= 9
-          !NSBundle.mainBundle.bundlePath.start_with?('/var/')
+          NSBundle.mainBundle.bundlePath !~ /^(\/private)?\/var/
         else
           !(UIDevice.currentDevice.model =~ /simulator/i).nil?
         end


### PR DESCRIPTION
iOS 13 moved the `bundlePath` from `/var/...` to `/private/var/...`. So it was incorrectly returning `true` on device.