### PR TITLE
tvOS fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .rake_tasks~
 pkg/*
 build/
+build-log/
 .DS_Store
 .repl_history

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ script:
   - bundle exec rake clean
   - bundle exec rake spec target=10
   - bundle exec rake clean
-  - bundle exec rake spec osx=true
+  - BW_PLATFORM=osx bundle exec rake spec
   - bundle exec rake clean
-  - bundle exec rake spec tvos=true
+  - BW_PLATFORM=tvos bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,22 @@
 language: objective-c
-osx_image: xcode8
+osx_image: xcode12.4
+env:
+  global:
+    - RUBYMOTION_LICENSE=1dcac45cc434293009f74b33037bdf7361a3a1ff # Official license key for open-source projects
+    - TMP_DIR=./tmp # For motion repo, so it doesn't attempt to use /tmp, to which it has no access
+    - OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 before_install:
+  - brew update
+  - brew outdated xctool || brew upgrade xctool
+  - (xcrun simctl list)
+  - wget http://travisci.rubymotion.com/ -O RubyMotion-TravisCI.pkg
+  - sudo installer -pkg RubyMotion-TravisCI.pkg -target /
+  - sudo mkdir -p ~/Library/RubyMotion/build
+  - sudo chown -R travis ~/Library/RubyMotion
+  - eval "sudo motion activate $RUBYMOTION_LICENSE"
   - sudo motion update
+  - (motion --version)
+  - (ruby --version)
   - motion repo
 script:
   - bundle exec rake clean
@@ -10,3 +25,5 @@ script:
   - bundle exec rake spec target=10
   - bundle exec rake clean
   - bundle exec rake spec osx=true
+  - bundle exec rake clean
+  - bundle exec rake spec tvos=true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
       metaclass (~> 0.0.1)
     mocha-on-bacon (0.2.2)
       mocha (>= 0.13.0)
-    rake (10.4.2)
+    rake (10.5.0)
     webstub (1.1.2)
 
 PLATFORMS

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,19 @@
 require "bundler/gem_tasks"
 $:.unshift("/Library/RubyMotion/lib")
-if ENV['osx']
-  require 'motion/project/template/osx'
-else
-  require 'motion/project/template/ios'
+case ENV['BW_PLATFORM']
+  when 'osx'
+    require 'motion/project/template/osx'
+  when 'tvos'
+    require 'motion/project/template/tvos'
+  else
+    require 'motion/project/template/ios'
 end
+
 Bundler.setup
 Bundler.require
 
-require 'bubble-wrap/all'
+require 'bubble-wrap/all' unless ENV['BW_PLATFORM'] == 'tvos'
+require 'bubble-wrap/tv' if ENV['BW_PLATFORM'] == 'tvos'
 require 'bubble-wrap/test'
 
 module Motion
@@ -26,13 +31,22 @@ Motion::Project::App.setup do |app|
   app.identifier = 'io.bubblewrap.testSuite'
   app.specs_dir = './spec/motion'
   app.spec_files
-  if Motion::Project::App.osx?
+  case
+  when Motion::Project::App.osx?
     app.spec_files -= Dir.glob("./spec/motion/**/ios/**.rb")
-    ["font", "motion", "location", "media", "ui", "mail", "sms", "network-indicator"].each do |package|
+    %w(font motion location media ui mail sms network-indicator).each do |package|
+      app.spec_files -= Dir.glob("./spec/motion/#{package}/**/*.rb")
+    end
+  when Motion::Project::App.tvos?
+    app.deployment_target = '10.2'
+    app.info_plist['NSLocationAlwaysUsageDescription'] = 'Description'
+    app.info_plist['NSLocationWhenInUseUsageDescription'] = 'Description'
+    app.spec_files -= Dir.glob("./spec/motion/**/osx/**.rb")
+    %w(mail sms).each do |package|
       app.spec_files -= Dir.glob("./spec/motion/#{package}/**/*.rb")
     end
   else
-    app.deployment_target = '7.1'
+    app.deployment_target = '11.3'
     app.info_plist['NSLocationAlwaysUsageDescription'] = 'Description'
     app.info_plist['NSLocationWhenInUseUsageDescription'] = 'Description'
 

--- a/Rakefile
+++ b/Rakefile
@@ -47,6 +47,8 @@ Motion::Project::App.setup do |app|
     end
   else
     app.deployment_target = '11.3'
+    app.info_plist['NSCameraUsageDescription'] = 'Description'
+    app.info_plist['NSPhotoLibraryUsageDescription'] = 'Description'
     app.info_plist['NSLocationAlwaysUsageDescription'] = 'Description'
     app.info_plist['NSLocationWhenInUseUsageDescription'] = 'Description'
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,8 +12,7 @@ end
 Bundler.setup
 Bundler.require
 
-require 'bubble-wrap/all' unless ENV['BW_PLATFORM'] == 'tvos'
-require 'bubble-wrap/tv' if ENV['BW_PLATFORM'] == 'tvos'
+require 'bubble-wrap/all'
 require 'bubble-wrap/test'
 
 module Motion
@@ -42,8 +41,11 @@ Motion::Project::App.setup do |app|
     app.info_plist['NSLocationAlwaysUsageDescription'] = 'Description'
     app.info_plist['NSLocationWhenInUseUsageDescription'] = 'Description'
     app.spec_files -= Dir.glob("./spec/motion/**/osx/**.rb")
-    %w(mail sms).each do |package|
+    %w(font mail media motion sms ui).each do |package|
       app.spec_files -= Dir.glob("./spec/motion/#{package}/**/*.rb")
+    end
+    %w(ios osx).each do |platform|
+      app.spec_files -= Dir.glob("./spec/motion/**/#{platform}/**.rb")
     end
   else
     app.deployment_target = '11.3'
@@ -52,7 +54,9 @@ Motion::Project::App.setup do |app|
     app.info_plist['NSLocationAlwaysUsageDescription'] = 'Description'
     app.info_plist['NSLocationWhenInUseUsageDescription'] = 'Description'
 
-    app.spec_files -= Dir.glob("./spec/motion/**/osx/**.rb")
+    %w(osx tvos).each do |platform|
+      app.spec_files -= Dir.glob("./spec/motion/**/#{platform}/**.rb")
+    end
   end
 
   app.version       = '1.2.3'

--- a/lib/bubble-wrap/core.rb
+++ b/lib/bubble-wrap/core.rb
@@ -15,6 +15,11 @@ BubbleWrap.require_ios do
   require 'bubble-wrap/ui'
 end
 
+BubbleWrap.require_tvos do
+  BubbleWrap.require('motion/core/tvos/**/*.rb')
+  BubbleWrap.require('motion/core/device/tvos/**/*.rb')
+end
+
 BubbleWrap.require_osx do
   BubbleWrap.require('motion/core/osx/**/*.rb')
   BubbleWrap.require('motion/core/device/osx/**/*.rb')

--- a/lib/bubble-wrap/ext/motion_project_app.rb
+++ b/lib/bubble-wrap/ext/motion_project_app.rb
@@ -37,6 +37,9 @@ module BubbleWrap
       def osx?
         self.respond_to?(:template) && self.template == :osx
       end
+      def tvos?
+        self.respond_to?(:template) && self.template == :tvos
+      end
     end
   end
 end

--- a/lib/bubble-wrap/loader.rb
+++ b/lib/bubble-wrap/loader.rb
@@ -25,7 +25,23 @@ unless defined?(BubbleWrap::LOADER_PRESENT)
     end
 
     def require_ios(requirement = nil, &callback)
-      if !Motion::Project::App.osx?
+      if !(Motion::Project::App.osx? || Motion::Project::App.tvos?)
+        callback.call
+      else
+        puts "bubble-wrap/#{requirement} requires iOS to use." if requirement
+      end
+    end
+
+    def require_tvos(requirement = nil, &callback)
+      if Motion::Project::App.tvos?
+        callback.call
+      else
+        puts "bubble-wrap/#{requirement} requires tvOS to use." if requirement
+      end
+    end
+
+    def require_xos(requirement = nil, &callback) # tvos & ios, not macos
+      if !(Motion::Project::App.osx?)
         callback.call
       else
         puts "bubble-wrap/#{requirement} requires iOS to use." if requirement

--- a/lib/bubble-wrap/location.rb
+++ b/lib/bubble-wrap/location.rb
@@ -1,6 +1,6 @@
 require 'bubble-wrap/loader'
 
-BubbleWrap.require_ios("location") do
+BubbleWrap.require_xos("location") do
   BubbleWrap.require('motion/util/constants.rb')
   BubbleWrap.require('motion/core/string.rb')
   BubbleWrap.require('motion/location/**/*.rb') do

--- a/lib/bubble-wrap/network-indicator.rb
+++ b/lib/bubble-wrap/network-indicator.rb
@@ -1,6 +1,6 @@
 require 'bubble-wrap/loader'
 
-BubbleWrap.require_ios("network-indicator") do
+BubbleWrap.require_xos("network-indicator") do
   BubbleWrap.require('motion/core/app.rb')
   BubbleWrap.require('motion/network-indicator/**/*.rb')
 end

--- a/lib/bubble-wrap/tv.rb
+++ b/lib/bubble-wrap/tv.rb
@@ -1,15 +1,12 @@
-# This is 'all' for for the tvOS
+# This is 'all' for tvOS
 require File.expand_path('../loader', __FILE__)
 [
   'core',
-  'font',
   'location',
-  'media',
   'motion',
   'network-indicator',
   'reactor',
   'rss_parser',
-  'ui',
 ].each { |sub|
 	require File.expand_path("../#{sub}", __FILE__)
 }

--- a/lib/bubble-wrap/tv.rb
+++ b/lib/bubble-wrap/tv.rb
@@ -1,0 +1,15 @@
+# This is 'all' for for the tvOS
+require File.expand_path('../loader', __FILE__)
+[
+  'core',
+  'font',
+  'location',
+  'media',
+  'motion',
+  'network-indicator',
+  'reactor',
+  'rss_parser',
+  'ui',
+].each { |sub|
+	require File.expand_path("../#{sub}", __FILE__)
+}

--- a/motion/core/app.rb
+++ b/motion/core/app.rb
@@ -98,7 +98,11 @@ module BubbleWrap
     end
 
     def ios?
-      Kernel.const_defined?(:UIApplication)
+      Kernel.const_defined?(:UIApplication) && !tvos?
+    end
+
+    def tvos?
+      UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomTV
     end
   end
 

--- a/motion/core/device/tvos/screen.rb
+++ b/motion/core/device/tvos/screen.rb
@@ -1,0 +1,60 @@
+module BubbleWrap
+  module Device
+    module Screen
+
+      module_function
+
+      # Certifies that the device running the app has a Retina display
+      # @return [TrueClass, FalseClass] true will be returned if the device has a Retina display, false otherwise.
+      def retina?(_=UIScreen.mainScreen)
+        false
+      end
+
+      # Figure out the current physical orientation of the device
+      # @return [:portrait, :portrait_upside_down, :landscape_left, :landscape_right, :face_up, :face_down, :unknown]
+      def orientation(device_orientation=UIDevice.currentDevice.orientation, fallback=true)
+        :landscape
+      end
+
+      # Figure out the current orientation of the interface
+      # @return [:portrait, :portrait_upside_down, :landscape_left, :landscape_right]
+      def interface_orientation(device_orientation=UIDevice.currentDevice.orientation, fallback=true)
+        :landscape
+      end
+
+      # The width of the device's screen.
+      # The real resolution is dependant on the scale
+      # factor (see `retina?`) but the coordinate system
+      # is in non-retina pixels. You can get pixel
+      # accuracy by using half-coordinates.
+      # This is a Float
+      def width
+        UIScreen.mainScreen.bounds.size.width
+      end
+
+      # The height of the device's screen.
+      # The real resolution is dependant on the scale
+      # factor (see `retina?`) but the coordinate system
+      # is in non-retina pixels. You can get pixel
+      # accuracy by using half-coordinates.
+      # This is a Float
+      def height
+        UIScreen.mainScreen.bounds.size.height
+      end
+
+      # The same as `.width` and `.height` but
+      # compensating for screen rotation (which
+      # can do your head in).
+      def width_for_orientation(o=orientation)
+        width
+      end
+
+      # The same as `.width` and `.height` but
+      # compensating for screen rotation (which
+      # can do your head in).
+      def height_for_orientation(o=orientation)
+        height
+      end
+    end
+  end
+end

--- a/motion/core/tvos/app.rb
+++ b/motion/core/tvos/app.rb
@@ -1,0 +1,95 @@
+module BubbleWrap
+  module App
+    module_function
+
+    # Opens an url (string or instance of `NSURL`)
+    # in the device's web browser or in the correspondent app for custom schemas
+    # Usage Example:
+    #   App.open_url("http://matt.aimonetti.net")
+    #   App.open_url("fb://profile")
+    def open_url(url)
+      unless url.is_a?(NSURL)
+        url = NSURL.URLWithString(url)
+      end
+      UIApplication.sharedApplication.openURL(url)
+    end
+
+    # Returns whether an app can open a given URL resource (string or instance of `NSURL`)
+    # Useful to check if certain apps are installed before calling to their custom schemas.
+    # Usage Example:
+    #   App.open_url("fb://profile") if App.can_open_url("fb://")
+    def can_open_url(url)
+      unless url.is_a?(NSURL)
+        url = NSURL.URLWithString(url)
+      end
+      UIApplication.sharedApplication.canOpenURL(url)
+    end
+
+    # Displays a UIAlertView.
+    #
+    # title - The title as a String.
+    # args  - The title of the cancel button as a String, or a Hash of options.
+    #         (Default: { cancel_button_title: 'OK' })
+    #         cancel_button_title - The title of the cancel button as a String.
+    #         message             - The main message as a String.
+    # block - Yields the alert object if a block is given, and does so before the alert is shown.
+    #
+    # Returns an instance of BW::UIAlertView
+    def alert(title, *args, &block)
+      options = { cancel_button_title: 'OK' }
+      options.merge!(args.pop) if args.last.is_a?(Hash)
+
+      if args.size > 0 && args.first.is_a?(String)
+        options[:cancel_button_title] = args.shift
+      end
+
+      options[:title]               = title
+      options[:buttons]             = options[:cancel_button_title]
+      options[:cancel_button_index] = 0 # FIXME: alerts don't have "Cancel" buttons
+
+      alert = UIAlertView.default(options)
+
+      yield(alert) if block_given?
+
+      alert.show
+      alert
+    end
+
+    # Return application frame
+    def frame
+      UIScreen.mainScreen.applicationFrame
+    end
+
+    # Main Screen bounds. Useful when starting the app
+    def bounds
+      UIScreen.mainScreen.bounds
+    end
+
+    # Application Delegate
+    def delegate
+      UIApplication.sharedApplication.delegate
+    end
+
+    # the Application object.
+    def shared
+      UIApplication.sharedApplication
+    end
+
+    def windows
+      UIApplication.sharedApplication.windows
+    end
+
+    # the Application Window
+    def window
+      normal_windows = App.windows.select { |w|
+        w.windowLevel == UIWindowLevelNormal
+      }
+
+      key_window = normal_windows.select {|w|
+        w == UIApplication.sharedApplication.keyWindow
+      }.first
+
+      key_window || normal_windows.first
+    end
+  end
+end

--- a/motion/core/tvos/device.rb
+++ b/motion/core/tvos/device.rb
@@ -1,0 +1,6 @@
+module BubbleWrap
+  module Device
+    module_function
+
+  end
+end

--- a/spec/motion/core/device/ios/camera_spec.rb
+++ b/spec/motion/core/device/ios/camera_spec.rb
@@ -103,6 +103,14 @@ describe BubbleWrap::Device::Camera do
   end
 
   describe '.imagePickerControllerDidCancel' do
+    before do
+      UIImagePickerController.instance_eval do
+        def self.isSourceTypeAvailable(c)
+          return true
+        end
+      end
+    end
+
     it 'should yield the correct error when canceled' do
       callback_ran = false
 

--- a/spec/motion/reactor_spec.rb
+++ b/spec/motion/reactor_spec.rb
@@ -45,7 +45,7 @@ describe BubbleWrap::Reactor do
   describe '.add_periodic_timer' do
     it 'runs callbacks repeatedly' do
       @proxy.proof = 0
-      @timer = @subject.add_periodic_timer 0.5 do
+      @timer = @subject.add_periodic_timer 0.4 do
         @proxy.proof = @proxy.proof + 1
         @subject.cancel_timer(@timer) if @proxy.proof > 2
       end
@@ -60,7 +60,7 @@ describe BubbleWrap::Reactor do
         @proxy.proof = @proxy.proof + 1
         @subject.cancel_timer(@timer) if @proxy.proof > 2
       }
-      @timer = @subject.add_periodic_timer 0.5, callback
+      @timer = @subject.add_periodic_timer 0.4, callback
       wait 1.1 do
         @proxy.proof.should >= 2
       end


### PR DESCRIPTION
Makes BubbleWrap compatible with tvOS. 
 - based on the OS X (macOS) support
 - mostly just removing parts of BubbleWrap that use SDK's not present in tvOS

Also updated the travis.yml to the new standard.

Note: There is a failure in the build, in the Reactor support, which exists on the master branch before this change. I'm not sure how to fix it.